### PR TITLE
Add license management CLI and balance helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,3 +92,63 @@
 - Replace placeholder mint and authority addresses with real ones and secure key
   management for the distributor.
 - Extend unit tests to mock RPC responses and cover the license check logic.
+
+## Codex Agent - Advanced License Management
+
+**Date:** 2025-07-29
+
+### Summary
+- Introduced demo licensing via a second SPL mint (`DEMO_MINT`).
+- `LicenseManager` now detects full/demo licenses, creates token accounts on
+  distribution, and exports `verify_or_exit` for enforcement.
+- Environment variables allow runtime configuration of `LICENSE_MINT`,
+  `DEMO_MINT`, and `LICENSE_AUTHORITY`.
+- `main.py` calls `verify_or_exit` and warns when running in demo mode.
+- Updated README with detailed setup instructions and environment variable usage.
+- Extended utils exports to include `DEMO_MINT`.
+
+### Design Decisions
+- Demo mode lets users observe output without trading, lowering the barrier to
+  trial while keeping full functionality gated by an on-chain token.
+- License distribution creates associated token accounts when necessary to avoid
+  manual setup for new users.
+
+### Next Steps
+- Implement secure storage for the authority keypair when distributing licenses.
+- Add tests covering the new demo checks and `verify_or_exit` logic.
+
+## Codex Agent - Secure Keypair Storage
+
+**Date:** 2025-07-30
+
+### Summary
+- Added encrypted keypair loading via `LICENSE_KEYPAIR_PATH` and
+  `LICENSE_KEYPAIR_KEY` environment variables.
+- `load_authority_keypair` decrypts the keypair with Fernet.
+- `LicenseManager.distribute_license` now loads the keypair automatically when
+  none is provided.
+- Updated utils exports and README with instructions on secure keypair storage.
+- Added a unit test for keypair loading.
+
+### Design Decisions
+- `cryptography` dependency introduced for symmetric encryption. The encrypted
+  keypair prevents accidental leakage of the authority secret key.
+
+### Next Steps
+- Extend CLI tooling for automated license distribution.
+
+## Codex Agent - License CLI Expansion
+
+**Date:** 2025-07-30
+
+### Summary
+- Added `solbot.tools.distribute_license` module providing a command line utility to send license tokens
+- Extended `LicenseManager` with helpers `token_accounts`, `token_balance`, `license_balance` and `fetch_license_account`
+- Updated README with instructions for the new distributor and environment variable usage
+
+### Design Decisions
+- CLI arguments mirror environment variables so the authority wallet path and decryption key can be provided at runtime
+- Balance queries aggregate across all token accounts to support multiple wallets holding licenses
+
+### Next Steps
+- Implement caching of RPC responses to reduce network load during frequent checks

--- a/README.md
+++ b/README.md
@@ -74,17 +74,37 @@ Environment variables with the same name override defaults. See `--help` for all
 
 Before full functionality is enabled the bot verifies that your wallet holds a
 valid license token on Solana. Provide your wallet public key with `--wallet`
-or the `WALLET_ADDR` environment variable. The default mint and authority
-addresses are placeholders in `solbot.utils.license` and must be updated by the
-project owner.
+or the `WALLET_ADDR` environment variable. The mint and authority addresses are
+configured via environment variables:
+
+```bash
+export LICENSE_MINT=<FULL_LICENSE_MINT>
+export DEMO_MINT=<DEMO_LICENSE_MINT>
+export LICENSE_AUTHORITY=<ISSUER_PUBLIC_KEY>
+export LICENSE_KEYPAIR_PATH=/secure/location/authority.json.enc
+export LICENSE_KEYPAIR_KEY=<BASE64_FERNET_KEY>
+```
+
+If the wallet contains `LICENSE_MINT` the bot runs in full mode. Holding only
+`DEMO_MINT` enables read-only demo mode.
 
 ```bash
 python -m src.main --wallet YOUR_WALLET --rpc-ws wss://api.mainnet-beta.solana.com/
 ```
 
 If no license token is detected the program exits with a message. A minimal
-license distributor is included to send license tokens from the authority
-wallet.
+license distributor is provided to send license tokens from the authority
+wallet. Run it as a module and pass the recipient wallet address:
+
+```bash
+python -m solbot.tools.distribute_license RECIPIENT_WALLET \
+    --rpc-http https://api.mainnet-beta.solana.com \
+    --keypair /secure/location/authority.json.enc \
+    --key $LICENSE_KEYPAIR_KEY
+```
+
+The distributor loads and decrypts the authority keypair from `--keypair` using
+the provided `--key` or the `LICENSE_KEYPAIR_KEY` environment variable.
 
 ## Agent Workflow
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,4 +10,5 @@ requires-python = ">=3.10"
 dependencies = [
     "websockets>=10",
     "solana>=0.30",
+    "cryptography>=41",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 websockets>=10
 pytest>=7
 solana>=0.30
+cryptography>=41

--- a/src/main.py
+++ b/src/main.py
@@ -8,7 +8,6 @@ from solbot.utils import (
     parse_args,
     BotConfig,
     LicenseManager,
-    LICENSE_MINT,
 )
 
 
@@ -19,11 +18,12 @@ def main() -> None:
     logging.basicConfig(level=getattr(logging, cfg.log_level.upper(), logging.INFO))
 
     lm = LicenseManager(rpc_http=cfg.rpc_ws.replace("wss://", "https://"))
-    if not cfg.wallet or not lm.has_license(cfg.wallet):
-        print(
-            "License check failed. Provide a valid wallet with a license token."
-        )
+    if not cfg.wallet:
+        print("--wallet is required")
         return
+    mode = lm.verify_or_exit(cfg.wallet)
+    if mode == "demo":
+        logging.warning("Demo mode active: trading disabled")
 
     streamer = data.SlotStreamer(cfg.rpc_ws)
     posterior = PosteriorEngine()

--- a/src/solbot/tools/__init__.py
+++ b/src/solbot/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Command line tools for sol-bot."""

--- a/src/solbot/tools/distribute_license.py
+++ b/src/solbot/tools/distribute_license.py
@@ -1,0 +1,51 @@
+"""CLI for distributing license tokens.
+
+This script sends a license SPL token from the authority wallet to a recipient.
+Use environment variables or command line options to specify the authority keypair
+and RPC endpoint.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+from solbot.utils.license import LicenseManager, load_authority_keypair
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command line options."""
+    parser = argparse.ArgumentParser(description="Send a license token")
+    parser.add_argument("recipient", help="Wallet address receiving the license")
+    parser.add_argument(
+        "--rpc-http",
+        default=os.getenv("RPC_HTTP", "https://api.mainnet-beta.solana.com"),
+        help="Solana RPC endpoint",
+    )
+    parser.add_argument(
+        "--keypair",
+        default=os.getenv("LICENSE_KEYPAIR_PATH", ""),
+        help="Path to the encrypted authority keypair",
+    )
+    parser.add_argument(
+        "--key",
+        default=os.getenv("LICENSE_KEYPAIR_KEY", ""),
+        help="Base64 Fernet key for the authority keypair",
+    )
+    parser.add_argument(
+        "--demo",
+        action="store_true",
+        help="Send a demo license instead of a full license",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Run the distributor."""
+    args = parse_args(argv)
+    lm = LicenseManager(rpc_http=args.rpc_http)
+    kp = load_authority_keypair(path=args.keypair or None, key=args.key or None)
+    sig = lm.distribute_license(args.recipient, keypair=kp, demo=args.demo)
+    print(f"License sent in transaction {sig}")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual usage
+    main()

--- a/src/solbot/utils/__init__.py
+++ b/src/solbot/utils/__init__.py
@@ -1,7 +1,15 @@
 """Generic utility functions."""
 
 from .config import BotConfig, parse_args
-from .license import LicenseManager, LICENSE_MINT, LICENSE_AUTHORITY
+from .license import (
+    LicenseManager,
+    LICENSE_MINT,
+    DEMO_MINT,
+    LICENSE_AUTHORITY,
+    LICENSE_KEYPAIR_PATH,
+    LICENSE_KEYPAIR_KEY,
+    load_authority_keypair,
+)
 
 __all__ = [
     "BotConfig",
@@ -9,5 +17,9 @@ __all__ = [
     "LicenseManager",
     "LICENSE_MINT",
     "LICENSE_AUTHORITY",
+    "DEMO_MINT",
+    "LICENSE_KEYPAIR_PATH",
+    "LICENSE_KEYPAIR_KEY",
+    "load_authority_keypair",
 ]
 

--- a/src/solbot/utils/license.py
+++ b/src/solbot/utils/license.py
@@ -1,17 +1,63 @@
-"""License distribution and verification via Solana."""
+"""License distribution and verification via Solana.
+
+This module verifies that a user holds an on-chain license token before enabling
+full functionality. Licenses are standard SPL tokens minted by an authority
+wallet. A second mint may be issued for ``demo`` mode which allows users to
+explore the interface without placing trades.
+
+Replace the constants below with real addresses or set the corresponding
+environment variables at runtime.
+"""
 
 from dataclasses import dataclass
+import os
+import json
+from cryptography.fernet import Fernet
 from solana.rpc.api import Client
 from solders.transaction import Transaction
 from solders.pubkey import Pubkey
 from solders.keypair import Keypair
-from spl.token.instructions import transfer, get_associated_token_address
+from spl.token.instructions import (
+    transfer,
+    get_associated_token_address,
+    create_associated_token_account,
+)
 from spl.token.constants import TOKEN_PROGRAM_ID
 
 # Address of the SPL token mint representing a valid license.
-LICENSE_MINT = "REPLACE_WITH_LICENSE_MINT"  # TODO: set actual mint address
+LICENSE_MINT = os.getenv("LICENSE_MINT", "REPLACE_WITH_LICENSE_MINT")
+# Address of the SPL token mint granting demo (read-only) access.
+DEMO_MINT = os.getenv("DEMO_MINT", "REPLACE_WITH_DEMO_MINT")
 # Address of the wallet that issues licenses.
-LICENSE_AUTHORITY = "REPLACE_WITH_AUTHORITY_WALLET"  # TODO: set actual authority
+LICENSE_AUTHORITY = os.getenv("LICENSE_AUTHORITY", "REPLACE_WITH_AUTHORITY_WALLET")
+# Path to the encrypted authority keypair used for distribution.
+LICENSE_KEYPAIR_PATH = os.getenv("LICENSE_KEYPAIR_PATH", "")
+# Base64 encoded Fernet key to decrypt the authority keypair file.
+LICENSE_KEYPAIR_KEY = os.getenv("LICENSE_KEYPAIR_KEY", "")
+
+
+def load_authority_keypair(path: str | None = None, key: str | None = None) -> Keypair:
+    """Load and decrypt the authority keypair.
+
+    Parameters
+    ----------
+    path:
+        Optional path to the encrypted keypair file. Defaults to
+        ``LICENSE_KEYPAIR_PATH``.
+    key:
+        Optional base64 encoded Fernet key used to decrypt ``path``. Defaults to
+        ``LICENSE_KEYPAIR_KEY``. If empty the file is assumed to be plaintext.
+    """
+    path = path or LICENSE_KEYPAIR_PATH
+    key = key or LICENSE_KEYPAIR_KEY
+    if not path:
+        raise ValueError("no keypair path specified")
+    with open(path, "rb") as fh:
+        data = fh.read()
+    if key:
+        data = Fernet(key).decrypt(data)
+    secret = json.loads(data)
+    return Keypair.from_bytes(bytes(secret))
 
 
 @dataclass
@@ -23,30 +69,110 @@ class LicenseManager:
     def _client(self) -> Client:
         return Client(self.rpc_http)
 
+    def _has_token(self, wallet: str, mint: str) -> bool:
+        """Return ``True`` if ``wallet`` owns at least one token of ``mint``."""
+        client = self._client()
+        try:
+            resp = client.get_token_accounts_by_owner(
+                Pubkey.from_string(wallet), {"mint": Pubkey.from_string(mint)}
+            )
+            accounts = resp.get("result", {}).get("value", [])
+            return len(accounts) > 0
+        except Exception:
+            return False
+
+    def token_accounts(self, wallet: str, mint: str) -> list[dict]:
+        """Return all token accounts for ``wallet`` and ``mint``."""
+        client = self._client()
+        resp = client.get_token_accounts_by_owner(
+            Pubkey.from_string(wallet), {"mint": Pubkey.from_string(mint)}
+        )
+        return resp.get("result", {}).get("value", [])
+
+    def token_balance(self, wallet: str, mint: str) -> int:
+        """Return the balance of ``mint`` tokens held by ``wallet``."""
+        accounts = self.token_accounts(wallet, mint)
+        if not accounts:
+            return 0
+        client = self._client()
+        balance = 0
+        for acc in accounts:
+            info = client.get_token_account_balance(Pubkey.from_string(acc["pubkey"]))
+            amount = int(info["result"]["value"]["amount"])
+            balance += amount
+        return balance
+
+    def fetch_license_account(self, wallet: str) -> str | None:
+        """Return the first token account address holding a license, if any."""
+        accounts = self.token_accounts(wallet, LICENSE_MINT)
+        return accounts[0]["pubkey"] if accounts else None
+
     def has_license(self, wallet: str) -> bool:
-        """Check if the wallet holds the license token."""
-        client = self._client()
-        resp = client.get_token_accounts_by_owner(Pubkey.from_string(wallet), {
-            "mint": Pubkey.from_string(LICENSE_MINT)
-        })
-        accounts = resp.get("result", {}).get("value", [])
-        return len(accounts) > 0
+        """Return True if the wallet holds a full license."""
+        return self._has_token(wallet, LICENSE_MINT)
 
-    def distribute_license(self, recipient: str, keypair: Keypair) -> str:
-        """Transfer one license token to ``recipient``.
+    def has_demo(self, wallet: str) -> bool:
+        """Return True if the wallet holds a demo license."""
+        return self._has_token(wallet, DEMO_MINT)
 
-        The ``keypair`` must correspond to ``LICENSE_AUTHORITY``. This function
-        builds and sends a simple SPL token transfer transaction. The caller is
-        responsible for funding fees. The returned string is the transaction
-        signature.
+    def license_balance(self, wallet: str) -> int:
+        """Return the number of full license tokens owned by ``wallet``."""
+        return self.token_balance(wallet, LICENSE_MINT)
+
+    def license_mode(self, wallet: str) -> str:
+        """Return ``full``, ``demo`` or ``none`` for the given wallet."""
+        if self.license_balance(wallet) > 0:
+            return "full"
+        if self.has_demo(wallet):
+            return "demo"
+        return "none"
+
+    def distribute_license(
+        self, recipient: str, keypair: Keypair | None = None, demo: bool = False
+    ) -> str:
+        """Send a license token to ``recipient``.
+
+        Parameters
+        ----------
+        recipient:
+            Wallet receiving the license.
+        keypair:
+            Optional authority keypair. When ``None`` the keypair is loaded from
+            :func:`load_authority_keypair` and must match
+            :data:`LICENSE_AUTHORITY`.
+        demo:
+            If ``True`` the demo mint is sent, otherwise the full license mint is
+            used.
+
+        Returns
+        -------
+        str
+            Transaction signature of the transfer.
         """
+        keypair = keypair or load_authority_keypair()
+        if str(keypair.pubkey()) != LICENSE_AUTHORITY:
+            raise ValueError("authority mismatch")
+
+        mint = DEMO_MINT if demo else LICENSE_MINT
         client = self._client()
-        source_token = get_associated_token_address(
-            keypair.pubkey(), Pubkey.from_string(LICENSE_MINT)
-        )
-        dest_token = get_associated_token_address(
-            Pubkey.from_string(recipient), Pubkey.from_string(LICENSE_MINT)
-        )
+
+        source_token = get_associated_token_address(keypair.pubkey(), Pubkey.from_string(mint))
+        dest_token = get_associated_token_address(Pubkey.from_string(recipient), Pubkey.from_string(mint))
+
+        # Create destination account if required
+        try:
+            acc = client.get_account_info(dest_token)
+            if acc.get("result", {}).get("value") is None:
+                raise Exception
+        except Exception:
+            create_instr = create_associated_token_account(
+                payer=keypair.pubkey(),
+                owner=Pubkey.from_string(recipient),
+                mint=Pubkey.from_string(mint),
+            )
+            tx = Transaction().add(create_instr)
+            client.send_transaction(tx, keypair)
+
         tx = Transaction().add(
             transfer(
                 source=source_token,
@@ -58,3 +184,16 @@ class LicenseManager:
         )
         resp = client.send_transaction(tx, keypair)
         return resp["result"]
+
+    def verify_or_exit(self, wallet: str) -> str:
+        """Ensure ``wallet`` has a license, exiting the process if not."""
+        mode = self.license_mode(wallet)
+        if mode == "none":
+            import sys
+
+            print(
+                "License check failed. Obtain a license token from the"
+                f" authority wallet {LICENSE_AUTHORITY}."
+            )
+            sys.exit(1)
+        return mode

--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -1,4 +1,13 @@
-from solbot.utils.license import LicenseManager, LICENSE_MINT
+import pytest
+from solders.pubkey import Pubkey
+from solbot.utils.license import (
+    LicenseManager,
+    LICENSE_MINT,
+    DEMO_MINT,
+    load_authority_keypair,
+)
+from solders.keypair import Keypair
+from cryptography.fernet import Fernet
 
 class DummyClient:
     def __init__(self, result):
@@ -17,3 +26,75 @@ def test_has_license(monkeypatch):
     monkeypatch.setattr(lm, "_client", fake_client.__get__(lm))
     monkeypatch.setattr("solbot.utils.license.LICENSE_MINT", "11111111111111111111111111111111")
     assert lm.has_license("11111111111111111111111111111111")
+
+
+def test_license_mode_demo(monkeypatch):
+    lm = LicenseManager(rpc_http="https://example")
+
+    monkeypatch.setattr("solbot.utils.license.LICENSE_MINT", "11111111111111111111111111111111")
+
+    demo_mint = "1111111QLbz7JHiBTspS962RLKV8GndWFwiEaqKM"
+    monkeypatch.setattr("solbot.utils.license.DEMO_MINT", demo_mint)
+
+    class DemoClient:
+        def get_token_accounts_by_owner(self, owner, opts):
+            if opts.get("mint") == Pubkey.from_string(demo_mint):
+                return {"result": {"value": ["demo"]}}
+            return {"result": {"value": []}}
+
+    monkeypatch.setattr(lm, "_client", lambda: DemoClient())
+    assert lm.license_mode("11111111111111111111111111111111") == "demo"
+
+
+def test_verify_or_exit(monkeypatch):
+    lm = LicenseManager(rpc_http="https://example")
+
+    monkeypatch.setattr(lm, "license_mode", lambda wallet: "none")
+    with pytest.raises(SystemExit):
+        lm.verify_or_exit("bad")
+
+
+def test_load_authority_keypair(tmp_path, monkeypatch):
+    keypair = Keypair()
+    secret = keypair.to_json().encode()
+    key = Fernet.generate_key()
+    enc = Fernet(key).encrypt(secret)
+    path = tmp_path / "kp.enc"
+    path.write_bytes(enc)
+    monkeypatch.setenv("LICENSE_KEYPAIR_PATH", str(path))
+    monkeypatch.setenv("LICENSE_KEYPAIR_KEY", key.decode())
+    monkeypatch.setattr("solbot.utils.license.LICENSE_KEYPAIR_PATH", str(path))
+    monkeypatch.setattr("solbot.utils.license.LICENSE_KEYPAIR_KEY", key.decode())
+    loaded = load_authority_keypair()
+    assert loaded.pubkey() == keypair.pubkey()
+
+class BalanceClient:
+    def __init__(self, amount):
+        self.amount = amount
+    def get_token_accounts_by_owner(self, owner, opts):
+        # return a valid 32 byte pubkey string for the dummy token account
+        return {"result": {"value": [{"pubkey": "11111111111111111111111111111111"}]}}
+    def get_token_account_balance(self, pubkey):
+        return {"result": {"value": {"amount": str(self.amount)}}}
+
+def test_license_balance(monkeypatch):
+    lm = LicenseManager(rpc_http="https://example")
+    monkeypatch.setattr(lm, "_client", lambda: BalanceClient(2))
+    monkeypatch.setattr("solbot.utils.license.LICENSE_MINT", "11111111111111111111111111111111")
+    assert lm.license_balance("11111111111111111111111111111111") == 2
+
+
+def test_distributor_cli(monkeypatch, capsys):
+    called = {}
+    def fake_dist(self, recipient, keypair=None, demo=False):
+        called["recipient"] = recipient
+        called["demo"] = demo
+        return "sig"
+    monkeypatch.setattr(LicenseManager, "distribute_license", fake_dist)
+    monkeypatch.setattr("solbot.tools.distribute_license.load_authority_keypair", lambda path=None, key=None: "kp")
+    from solbot.tools import distribute_license
+    distribute_license.main(["dest", "--rpc-http", "https://example", "--demo"])
+    out = capsys.readouterr().out
+    assert "sig" in out
+    assert called["recipient"] == "dest"
+    assert called["demo"] is True


### PR DESCRIPTION
## Summary
- introduce `solbot.tools.distribute_license` command line tool for license distribution
- extend `LicenseManager` with balance helpers and token account lookup
- document distributor usage in README
- test new CLI and balance logic

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888baef3f50832eb420f2b98acf0706