### PR TITLE
Improve Python 3.9 compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,3 +152,19 @@
 
 ### Next Steps
 - Implement caching of RPC responses to reduce network load during frequent checks
+
+## Codex Agent - Python Compatibility
+
+**Date:** 2025-07-31
+
+### Summary
+- Updated configuration and license modules to avoid the Python 3.10 ``|`` union
+  syntax so the project can run on Python 3.9.
+- Adjusted the license distribution CLI accordingly.
+
+### Design Decisions
+- Introduced ``typing.Optional`` imports and replaced union type hints with
+  ``Optional`` generics where applicable.
+
+### Next Steps
+- Clarify the minimum supported Python version in the documentation.

--- a/src/solbot/tools/distribute_license.py
+++ b/src/solbot/tools/distribute_license.py
@@ -8,10 +8,11 @@ from __future__ import annotations
 
 import argparse
 import os
+from typing import Optional, List
 from solbot.utils.license import LicenseManager, load_authority_keypair
 
 
-def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     """Parse command line options."""
     parser = argparse.ArgumentParser(description="Send a license token")
     parser.add_argument("recipient", help="Wallet address receiving the license")
@@ -38,7 +39,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def main(argv: list[str] | None = None) -> None:
+def main(argv: Optional[List[str]] = None) -> None:
     """Run the distributor."""
     args = parse_args(argv)
     lm = LicenseManager(rpc_http=args.rpc_http)

--- a/src/solbot/utils/config.py
+++ b/src/solbot/utils/config.py
@@ -3,9 +3,10 @@
 from dataclasses import dataclass
 import argparse
 import os
+from typing import Optional, List
 
 
-def parse_args(args: list[str] | None = None) -> argparse.Namespace:
+def parse_args(args: Optional[List[str]] = None) -> argparse.Namespace:
     """Parse command line arguments or provided list."""
     parser = argparse.ArgumentParser(description="sol-bot configuration")
     parser.add_argument(

--- a/src/solbot/utils/license.py
+++ b/src/solbot/utils/license.py
@@ -12,6 +12,7 @@ environment variables at runtime.
 from dataclasses import dataclass
 import os
 import json
+from typing import Optional
 from cryptography.fernet import Fernet
 from solana.rpc.api import Client
 from solders.transaction import Transaction
@@ -36,7 +37,7 @@ LICENSE_KEYPAIR_PATH = os.getenv("LICENSE_KEYPAIR_PATH", "")
 LICENSE_KEYPAIR_KEY = os.getenv("LICENSE_KEYPAIR_KEY", "")
 
 
-def load_authority_keypair(path: str | None = None, key: str | None = None) -> Keypair:
+def load_authority_keypair(path: Optional[str] = None, key: Optional[str] = None) -> Keypair:
     """Load and decrypt the authority keypair.
 
     Parameters
@@ -102,7 +103,7 @@ class LicenseManager:
             balance += amount
         return balance
 
-    def fetch_license_account(self, wallet: str) -> str | None:
+    def fetch_license_account(self, wallet: str) -> Optional[str]:
         """Return the first token account address holding a license, if any."""
         accounts = self.token_accounts(wallet, LICENSE_MINT)
         return accounts[0]["pubkey"] if accounts else None
@@ -128,7 +129,7 @@ class LicenseManager:
         return "none"
 
     def distribute_license(
-        self, recipient: str, keypair: Keypair | None = None, demo: bool = False
+        self, recipient: str, keypair: Optional[Keypair] = None, demo: bool = False
     ) -> str:
         """Send a license token to ``recipient``.
 


### PR DESCRIPTION
## Summary
- make CLI utilities compatible with Python 3.9 by avoiding ``|`` unions
- document update in `AGENTS.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688aa43fb6c0832e8010f14f2c1144a7