### PR TITLE
refactor: remove py310 unions

### DIFF
--- a/src/solbot/engine/features.py
+++ b/src/solbot/engine/features.py
@@ -19,7 +19,7 @@ import os
 import time
 from collections import deque
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import numpy as np
 from prometheus_client import Gauge, Summary
@@ -83,8 +83,8 @@ class PyFeatureEngine(FeatureEngine):
         self.out = np.zeros(TOTAL_DIM, dtype=np.float32)
         self.last_touched = np.zeros(self.dim, dtype=np.int64)
         self._decay_slot = -1
-        self._slot: int | None = None
-        self._last_ts: int | None = None
+        self._slot: Optional[int] = None
+        self._last_ts: Optional[int] = None
         self._cum_liq = 0.0
 
     # ------------------------------------------------------------------

--- a/src/solbot/engine/trade.py
+++ b/src/solbot/engine/trade.py
@@ -1,7 +1,7 @@
 """Simplistic in-memory trade engine for paper trading."""
 
 from dataclasses import dataclass, field
-from typing import List
+from typing import List, Optional
 import asyncio
 
 from google.protobuf.json_format import MessageToDict
@@ -38,7 +38,9 @@ class TradeEngine:
         for token, pos in self.dal.load_positions().items():
             self.risk.positions[token] = pos
 
-    async def place_order(self, token: str, qty: float, side: Side, limit: float | None = None) -> Order:
+    async def place_order(
+        self, token: str, qty: float, side: Side, limit: Optional[float] = None
+    ) -> Order:
         async with self.lock:
             price = await self.connector.place_order(token, qty, side, limit)
             order = Order(token=token, quantity=qty, price=price, side=side, id=self.next_id)

--- a/src/solbot/exchange/connector.py
+++ b/src/solbot/exchange/connector.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import abc
+from typing import Optional
 
 from ..types import Side
 from ..persistence import DAL
@@ -17,14 +18,18 @@ class AbstractConnector(abc.ABC):
         self.oracle = oracle
 
     @abc.abstractmethod
-    async def place_order(self, token: str, qty: float, side: Side, limit: float | None = None) -> float:
+    async def place_order(
+        self, token: str, qty: float, side: Side, limit: Optional[float] = None
+    ) -> float:
         """Execute order and return executed price."""
 
 
 class PaperConnector(AbstractConnector):
     """Paper trading connector using the price oracle."""
 
-    async def place_order(self, token: str, qty: float, side: Side, limit: float | None = None) -> float:
+    async def place_order(
+        self, token: str, qty: float, side: Side, limit: Optional[float] = None
+    ) -> float:
         price = await self.oracle.price(token)
         if limit and ((side is Side.BUY and price > limit) or (side is Side.SELL and price < limit)):
             raise ValueError("limit not reached")
@@ -32,10 +37,14 @@ class PaperConnector(AbstractConnector):
 
 
 class SolanaConnector(AbstractConnector):
-    async def place_order(self, token: str, qty: float, side: Side, limit: float | None = None) -> float:
+    async def place_order(
+        self, token: str, qty: float, side: Side, limit: Optional[float] = None
+    ) -> float:
         raise NotImplementedError
 
 
 class BinanceConnector(AbstractConnector):
-    async def place_order(self, token: str, qty: float, side: Side, limit: float | None = None) -> float:
+    async def place_order(
+        self, token: str, qty: float, side: Side, limit: Optional[float] = None
+    ) -> float:
         raise NotImplementedError

--- a/src/solbot/persistence/assets.py
+++ b/src/solbot/persistence/assets.py
@@ -2,7 +2,7 @@
 
 import os
 import httpx
-from typing import List, Dict
+from typing import List, Dict, Optional
 import hashlib
 
 from .dal import DAL
@@ -11,7 +11,7 @@ from .dal import DAL
 class AssetService:
     """Fetch and store asset metadata."""
 
-    def __init__(self, dal: DAL, url: str | None = None) -> None:
+    def __init__(self, dal: DAL, url: Optional[str] = None) -> None:
         self.dal = dal
         self.url = url or os.getenv(
             "ASSET_LIST_URL",

--- a/src/solbot/persistence/dal.py
+++ b/src/solbot/persistence/dal.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 """Data access layer using SQLModel for persistence."""
 
 from datetime import datetime, timedelta
-from typing import List, Dict
+from typing import List, Dict, Optional
 
 from sqlmodel import SQLModel, Field, create_engine, Session, select
 import os
@@ -11,8 +11,9 @@ from hashlib import sha256
 
 from solbot.schema import PositionState, SCHEMA_HASH
 
+
 class DBOrder(SQLModel, table=True):
-    id: int | None = Field(default=None, primary_key=True)
+    id: Optional[int] = Field(default=None, primary_key=True)
     token: str
     quantity: float
     side: str
@@ -27,9 +28,9 @@ class DBPosition(SQLModel, table=True):
 
 class DBAsset(SQLModel, table=True):
     symbol: str = Field(primary_key=True)
-    mint: str | None = None
-    decimals: int | None = None
-    chain_id: int | None = None
+    mint: Optional[str] = None
+    decimals: Optional[int] = None
+    chain_id: Optional[int] = None
 
 
 class DBPrice(SQLModel, table=True):
@@ -61,7 +62,7 @@ class DAL:
                 session.add(DBMeta(key="schema_hash", value=SCHEMA_HASH))
             session.commit()
 
-    def get_meta(self, key: str) -> str | None:
+    def get_meta(self, key: str) -> Optional[str]:
         with Session(self.engine) as session:
             row = session.get(DBMeta, key)
             return row.value if row else None
@@ -82,7 +83,7 @@ class DAL:
         with Session(self.engine) as session:
             return session.exec(select(DBOrder).order_by(DBOrder.id)).all()
 
-    def upsert_position(self, pos: PositionState | None) -> None:
+    def upsert_position(self, pos: Optional[PositionState]) -> None:
         if not pos:
             return
         with Session(self.engine) as session:
@@ -134,7 +135,7 @@ class DAL:
             )
             session.commit()
 
-    def last_price(self, token: str) -> float | None:
+    def last_price(self, token: str) -> Optional[float]:
         with Session(self.engine) as session:
             p = session.get(DBPrice, token)
             if not p:

--- a/src/solbot/server/api.py
+++ b/src/solbot/server/api.py
@@ -10,6 +10,7 @@ from fastapi.security import APIKeyHeader
 from pydantic import BaseModel
 from prometheus_fastapi_instrumentator import Instrumentator
 from prometheus_client import Histogram
+from typing import Optional
 
 from ..utils import BotConfig, LicenseManager
 from ..engine import RiskManager, TradeEngine
@@ -23,7 +24,7 @@ class OrderRequest(BaseModel):
     token: str
     qty: float
     side: Side
-    limit: float | None = None
+    limit: Optional[float] = None
 
 
 class OrderResponse(BaseModel):
@@ -54,7 +55,7 @@ def create_app(
     connections: list[WebSocket] = []
     conn_lock = asyncio.Lock()
 
-    def check_key(key: str | None = Depends(api_key_header)) -> None:
+    def check_key(key: Optional[str] = Depends(api_key_header)) -> None:
         expected_hash = os.getenv("API_KEY_HASH")
         if expected_hash:
             import hashlib, hmac


### PR DESCRIPTION
## Summary
- replace Python 3.10 `|` unions with `typing.Optional`
- update connectors, DAL and API request models for Python 3.9 compatibility

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d7e9d7d3c832eaddcf34e908b8469