### PR TITLE
Add log stream metrics and backpressure checks

### DIFF
--- a/features.yaml
+++ b/features.yaml
@@ -1,22 +1,38 @@
 version: 0x01
 features:
-  - name: total_volume
+  - index: 0
+    name: liquidity_delta
     category: liquidity
-    event_kinds: [SWAP]
+    event_kinds: [ADD_LIQUIDITY, REMOVE_LIQUIDITY]
     unit: token
-  - name: last_swap_size
+    normalization: zscore
+  - index: 1
+    name: log_cum_liquidity
+    category: liquidity
+    event_kinds: [ADD_LIQUIDITY, REMOVE_LIQUIDITY]
+    unit: log_token
+    normalization: zscore
+  - index: 2
+    name: signed_volume
     category: orderflow
     event_kinds: [SWAP]
     unit: token
-  - name: liquidity_add
-    category: liquidity
-    event_kinds: [ADD_LIQUIDITY]
+    normalization: zscore
+  - index: 3
+    name: abs_volume
+    category: orderflow
+    event_kinds: [SWAP]
     unit: token
-  - name: liquidity_remove
-    category: liquidity
-    event_kinds: [REMOVE_LIQUIDITY]
-    unit: token
-  - name: minted_amount
+    normalization: zscore
+  - index: 4
+    name: swap_frequency
+    category: orderflow
+    event_kinds: [SWAP]
+    unit: per_ms
+    normalization: zscore
+  - index: 5
+    name: minted_amount
     category: ownership
     event_kinds: [MINT]
     unit: token
+    normalization: zscore

--- a/rustcore/Cargo.toml
+++ b/rustcore/Cargo.toml
@@ -12,6 +12,8 @@ pyo3 = { version = "0.20", features = ["extension-module"] }
 numpy = "0.20"
 crossbeam-channel = "0.5"
 once_cell = "1.19"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [dev-dependencies]
 criterion = "0.5"

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,7 +1,71 @@
+import asyncio
+import logging
+
 import pytest
+
 from solbot.solana import data
+from solbot.solana.data import DROPPED_LOGS, LogStreamer, reset_metrics
+from solbot.schema import EventKind
 
 
-def test_streamer_init():
-    s = data.SlotStreamer()
-    assert s.rpc_ws_url.startswith("ws")
+def test_event_stream_from_logs():
+    logs = ['{"type":"swap","ts":1,"amount_in":2.0,"amount_out":1.0}']
+    stream = data.EventStream(logs=logs)
+    ev = next(stream.stream_events())
+    assert ev.kind == EventKind.SWAP
+    assert ev.amount_in == 2.0
+
+
+def test_event_stream_throughput():
+    log = '{"type":"swap","ts":1,"amount_in":1.0,"amount_out":1.0}'
+    logs = [log] * 5000
+    stream = data.EventStream(logs=logs)
+    import time
+
+    gen = stream.stream_events()
+    start = time.perf_counter()
+    for _ in range(5000):
+        next(gen)
+    elapsed = time.perf_counter() - start
+    gen.close()
+    assert elapsed < 2.0
+
+
+def test_log_streamer_metrics_and_backpressure():
+    class Dummy(LogStreamer):
+        async def _connect(self):
+            for i in range(10):
+                yield f"log{i}"
+
+    reset_metrics()
+    logging.getLogger().setLevel(logging.CRITICAL)
+
+    async def run() -> float:
+        streamer = Dummy(queue_size=2)
+        agen = streamer.subscribe()
+        await agen.__anext__()  # start producer
+        await asyncio.sleep(0.1)
+        drops = DROPPED_LOGS.labels("main", "none")._value.get()
+        await agen.aclose()
+        return drops
+
+    drops = asyncio.run(run())
+    assert drops > 0
+
+
+def test_log_streamer_fail_fast():
+    class Infinite(LogStreamer):
+        async def _connect(self):
+            while True:
+                yield "log"
+
+    async def run() -> None:
+        streamer = Infinite(queue_size=4)
+        agen = streamer.subscribe()
+        await agen.__anext__()  # consume one
+        await asyncio.sleep(1.5)
+        with pytest.raises(RuntimeError):
+            await agen.__anext__()
+        await agen.aclose()
+
+    asyncio.run(run())

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from solbot.engine import PyFeatureEngine
+from solbot.engine.features import PyFeatureEngine
 from solbot.schema import Event, EventKind
 
 
@@ -99,3 +99,13 @@ def test_norm_decay_on_inactive_indices():
     delta = final_slot - 1
     expected_final = -(mu1 / np.sqrt(var1)) * np.sqrt(0.995 ** delta)
     assert np.isclose(fe.norm[0], expected_final, atol=1e-6)
+
+
+def test_history_ring_buffer():
+    fe = PyFeatureEngine()
+    ev = _mk_event(EventKind.SWAP, amount_in=1.0)
+    for _ in range(3):
+        fe.update(ev, slot=1)
+    hist = fe.history()
+    assert len(hist) == 3
+    assert hist[-1][0].kind == EventKind.SWAP

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -1,0 +1,17 @@
+import pytest
+from rustcore import parse_log
+
+
+@pytest.mark.benchmark
+def test_parse_log_latency(benchmark):
+    log = '{"type":"swap","ts":1,"amount_in":2.0,"amount_out":1.0}'
+
+    def run():
+        assert parse_log(log) is not None
+
+    benchmark.pedantic(run, iterations=10000, rounds=1)
+    stats = getattr(benchmark, "stats", None)
+    if stats is None:
+        pytest.skip("benchmark disabled")
+    mean = stats.stats.mean
+    assert mean * 1e6 < 100


### PR DESCRIPTION
## Summary
- add Prometheus queue depth gauge and dropped-log counter to log stream
- jitter reconnects with full-jitter backoff and fail-fast when queue exceeds 75%
- expose `program_id` metric labels and `reset_metrics()` helper; drain queue on shutdown

## Testing
- `cargo test -q`
- `pytest tests/test_data.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68900bbeb984832ebfa78d240d5bbd3d