### PR TITLE
feat: externalize license authority

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,3 +258,37 @@
 
 ### Next Steps
 - Execute the expanded audit starting with Bayesian posterior implementation and multi-market feature ingestion.
+
+## OpenAI Assistant - Admin Wallet Configuration
+
+**Date:** 2025-08-05
+
+### Summary
+- Enabled runtime configuration of `LICENSE_MINT` and `LICENSE_AUTHORITY` via environment variables.
+- Removed license distribution details from public documentation.
+- Hid authority wallet address from license failure message.
+
+### Next Steps
+- Populate the environment variables with real wallet and mint values when deploying.
+
+## OpenAI Assistant - Authority Wallet Bypass
+
+**Date:** 2025-08-05
+
+### Summary
+- Authority wallet automatically passes license checks, removing the need to issue a token to yourself.
+- Added tests covering the bypass logic.
+
+### Next Steps
+- Configure `LICENSE_AUTHORITY` to your personal wallet when running locally.
+
+## OpenAI Assistant - License Authority Lockdown
+
+**Date:** 2025-08-05
+
+### Summary
+- Hard-coded the default license authority to wallet `29xN3QQjDU3U24758y2RSz9L5gxc592BvURyb92rNunF`.
+- Set default keypair path to `/secrets/authority.json`.
+
+### Next Steps
+- Replace `LICENSE_MINT` and `DEMO_MINT` placeholders with real mint addresses once created.

--- a/README.md
+++ b/README.md
@@ -84,50 +84,6 @@ python -m src.main --rpc-ws wss://my.rpc/ws --log-level INFO
 Environment variables with the same name override defaults. See `--help` for all options.
 ```
 
-### License Verification
-
-Before full functionality is enabled the bot verifies that your wallet holds a
-valid license token on Solana. Provide your wallet public key with `--wallet`
-or the `WALLET_ADDR` environment variable. The mint and authority addresses are
-configured via environment variables:
-
-```bash
-export LICENSE_MINT=<FULL_LICENSE_MINT>
-export DEMO_MINT=<DEMO_LICENSE_MINT>
-export LICENSE_AUTHORITY=<ISSUER_PUBLIC_KEY>
-export LICENSE_KEYPAIR_PATH=/secure/location/authority.json.enc
-export LICENSE_KEYPAIR_KEY=<BASE64_FERNET_KEY>
-```
-
-If the wallet contains `LICENSE_MINT` the bot runs in full mode. Holding only
-`DEMO_MINT` enables read-only demo mode.
-
-```bash
-python -m src.main --wallet YOUR_WALLET --rpc-ws wss://api.mainnet-beta.solana.com/
-```
-
-If no license token is detected the program exits with a message. A legacy
-command line distributor exists for internal automation but is **deprecated**
-and not documented publicly.
-
-### License Issuer Service
-
-For production deployments a dedicated **License Issuer** service handles token
-distribution so that private keys never reside on developer machines. The
-service exposes a single authenticated endpoint:
-
-```http
-POST /issue
-Authorization: Bearer <JWT>
-{
-  "wallet": "DEST_WALLET",
-  "demo": false
-}
-```
-
-Requests must supply a short-lived JWT issued by the corporate identity
-provider. The encrypted authority keypair is loaded on demand and wiped from
-memory after signing.
 
 ## Operations
 

--- a/docs/operational_gaps.md
+++ b/docs/operational_gaps.md
@@ -26,9 +26,6 @@ This document records answers to the infrastructure questions raised during the 
 ## Regulatory / Audit
 - Order and balance logs retained 7 years. No PII stored.
 
-## Key Rotation Cadence
-- License authority rotated quarterly via ops script.
-
 ## Incident Process
 - PagerDuty alert on order latency or failed bootstrap. On-call engineer responds within 15m.
 
@@ -52,9 +49,6 @@ This document records answers to the infrastructure questions raised during the 
 
 ## Observability Endpoint Auth
 - `/metrics` available only on localhost; mTLS optional for remote deployments.
-
-## License Token Economics
-- License supply monitored; additional mints created if >80% distributed.
 
 ## Hotfix Path
 - Uvicorn reloads on SIGHUP allowing hot patches without downtime.

--- a/src/solbot/utils/__init__.py
+++ b/src/solbot/utils/__init__.py
@@ -10,7 +10,10 @@ from .license import (
     LICENSE_KEYPAIR_KEY,
     load_authority_keypair,
 )
-from ..service.license_issuer import app as license_issuer_app
+try:
+    from ..service.license_issuer import app as license_issuer_app
+except Exception:  # pragma: no cover
+    license_issuer_app = None
 from ..server import create_app as create_trading_app
 
 __all__ = [

--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -46,6 +46,15 @@ def test_license_mode_demo(monkeypatch):
     assert lm.license_mode("11111111111111111111111111111111") == "demo"
 
 
+def test_license_mode_authority(monkeypatch):
+    lm = LicenseManager(rpc_http="https://example")
+    admin = "11111111111111111111111111111111"
+    monkeypatch.setattr("solbot.utils.license.LICENSE_AUTHORITY", admin)
+    monkeypatch.setattr(lm, "license_balance", lambda wallet: 0)
+    monkeypatch.setattr(lm, "has_demo", lambda wallet: False)
+    assert lm.license_mode(admin) == "full"
+
+
 def test_verify_or_exit(monkeypatch):
     lm = LicenseManager(rpc_http="https://example")
 


### PR DESCRIPTION
## Summary
- allow setting license mint and authority via environment variables
- treat the authority wallet as automatically licensed
- handle optional license service import to avoid circular references
- hard-code default license authority and keypair path

## Testing
- `pip install -r requirements.txt`
- `pip install maturin`
- `maturin build --release`
- `pip install rustcore/target/wheels/rustcore-0.1.0-cp312-cp312-manylinux_2_34_x86_64.whl`
- `pytest tests/test_license.py tests/test_service.py tests/test_server.py tests/test_schema.py tests/test_perf.py tests/test_config.py tests/test_data.py tests/test_engine.py tests/test_features.py tests/test_feature_engine.py -q` *(KeyboardInterrupt after 18 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689030aba88c832e96d3b2ddb667bd4b