### PR TITLE
Fix disk IOPS path handling and event stream initialization

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -8,7 +8,6 @@ from solbot.engine import (
     RiskManager,
     PyFeatureEngine,
 )
-from solbot.schema import Event, EventKind
 from solbot.utils import (
     parse_args,
     BotConfig,
@@ -30,7 +29,7 @@ def main() -> None:
     if mode == "demo":
         logging.warning("Demo mode active: trading disabled")
 
-    streamer = data.EventStream(cfg.rpc_ws, events=[Event(ts=0, kind=EventKind.NONE)])
+    streamer = data.EventStream(cfg.rpc_ws)
     posterior = PosteriorEngine()
     risk = RiskManager()
     fe = PyFeatureEngine()

--- a/src/solbot/utils/syschecks.py
+++ b/src/solbot/utils/syschecks.py
@@ -19,6 +19,16 @@ def check_ntp(max_drift: float = 1.0) -> None:
 
 
 def disk_iops_test(path: str) -> float:
+    """Measure disk write IOPS by repeatedly writing a file.
+
+    The parent directory is created if it does not already exist so that callers
+    may freely supply paths under non-existent directories.
+    """
+
+    dir_path = os.path.dirname(path)
+    if dir_path:
+        os.makedirs(dir_path, exist_ok=True)
+
     start = time.perf_counter()
     for _ in range(100):
         with open(path, 'wb') as fh:

--- a/tests/test_syschecks.py
+++ b/tests/test_syschecks.py
@@ -1,0 +1,8 @@
+from solbot.utils.syschecks import disk_iops_test
+
+
+def test_disk_iops_creates_missing_dir(tmp_path):
+    path = tmp_path / "nested" / "iops.tmp"
+    iops = disk_iops_test(str(path))
+    assert iops > 0
+    assert not path.exists()


### PR DESCRIPTION
## Summary
- avoid FileNotFoundError by creating parent directories in `disk_iops_test`
- instantiate `EventStream` without unsupported arguments
- add regression test for disk IOPS helper

## Testing
- `pytest tests/test_syschecks.py tests/test_config.py tests/test_engine.py tests/test_features.py tests/test_perf.py tests/test_data.py tests/test_license.py tests/test_schema.py tests/test_server.py tests/test_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6891718a7868832e811b62ebb4564630