### PR TITLE
Handle NTP failures and update httpx

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -2,4 +2,4 @@ fastapi==0.105.0
 uvicorn==0.23.0
 cryptography==45.0.5
 prometheus-fastapi-instrumentator==6.1.0
-httpx==0.24.1
+httpx>=0.28

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "prometheus-fastapi-instrumentator==6.1.0",
     "prometheus-client>=0.16",
     "sqlmodel==0.0.8",
-    "httpx==0.24.1",
+    "httpx>=0.28",
     "ntplib==0.4.0",
     "pytest-benchmark>=3.4",
     "protobuf>=4.24",

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ fastapi==0.105.0
 uvicorn==0.23.0
 prometheus-fastapi-instrumentator==6.1.0
 prometheus-client>=0.16
-httpx==0.24.1
+httpx>=0.28
 sqlmodel==0.0.8
 ntplib==0.4.0
 protobuf>=4.24

--- a/src/solbot/utils/syschecks.py
+++ b/src/solbot/utils/syschecks.py
@@ -1,5 +1,6 @@
 import os
 import time
+import logging
 import ntplib
 
 
@@ -9,13 +10,17 @@ def ntp_drift() -> float:
     return resp.offset
 
 
+logger = logging.getLogger(__name__)
+
+
 def check_ntp(max_drift: float = 1.0) -> None:
     try:
         drift = abs(ntp_drift())
-        if drift > max_drift:
-            raise RuntimeError(f'NTP drift {drift:.2f}s exceeds limit')
     except Exception as e:
-        raise RuntimeError(f'NTP check failed: {e}')
+        logger.warning("NTP check failed: %s", e)
+        return
+    if drift > max_drift:
+        raise RuntimeError(f'NTP drift {drift:.2f}s exceeds limit')
 
 
 def disk_iops_test(path: str) -> float:


### PR DESCRIPTION
## Summary
- relax NTP time check to warn instead of crash when unreachable
- bump httpx dependency to >=0.28 for compatibility with solana client

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68917b2be7d0832e874c5ad0c9b9a2bc