### PR TITLE
Allow authority wallet bypass in API

### DIFF
--- a/src/solbot/server/api.py
+++ b/src/solbot/server/api.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import asyncio
 import time
+import logging
 from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect, Depends
 from fastapi.security import APIKeyHeader
 from pydantic import BaseModel
@@ -66,8 +67,11 @@ def create_app(
 
     @app.on_event("startup")
     async def check_license() -> None:
-        if not cfg.wallet or not lm.has_license(cfg.wallet):
+        mode = lm.license_mode(cfg.wallet) if cfg.wallet else "none"
+        if mode == "none":
             raise RuntimeError("wallet lacks license token")
+        if mode == "demo":
+            logging.warning("Demo mode active: trading disabled")
         if not bootstrap.is_ready():
             await bootstrap.run(assets, trade.connector.oracle)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -17,9 +17,9 @@ class DummyLM:
     def __init__(self) -> None:
         self.called = False
 
-    def has_license(self, wallet: str) -> bool:
+    def license_mode(self, wallet: str) -> str:
         self.called = True
-        return True
+        return "full"
 
 
 def test_api_order_flow():


### PR DESCRIPTION
## Summary
- permit the license authority wallet to bypass token checks in the FastAPI server
- log when demo licenses are used and update server test to use `license_mode`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6891e8ec92b8832eba2de15526a15a82