### PR TITLE
feat: expose features and posterior

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -8,7 +8,7 @@ sys.path.append(str(Path(__file__).resolve().parent))
 import uvicorn
 
 from solbot.utils import parse_args, BotConfig, LicenseManager
-from solbot.engine import RiskManager, TradeEngine
+from solbot.engine import RiskManager, TradeEngine, PyFeatureEngine, PosteriorEngine
 from solbot.server import create_app
 from solbot.persistence import DAL
 from solbot.persistence.assets import AssetService
@@ -29,10 +29,12 @@ def main() -> None:
     connector = PaperConnector(dal, oracle)
     risk = RiskManager()
     trade = TradeEngine(risk, connector, dal)
+    features = PyFeatureEngine()
+    posterior = PosteriorEngine(n_features=features.dim)
     assets = AssetService(dal)
     bootstrap = BootstrapCoordinator()
 
-    app = create_app(cfg, lm, risk, trade, assets, bootstrap)
+    app = create_app(cfg, lm, risk, trade, assets, bootstrap, features, posterior)
     uvicorn.run(app, host="127.0.0.1", port=8000)
 
 

--- a/src/solbot/engine/posterior.py
+++ b/src/solbot/engine/posterior.py
@@ -1,5 +1,7 @@
 """Posterior probability engine stubs."""
 
+"""Lightweight online posterior models for rug and regime probabilities."""
+
 from dataclasses import dataclass
 from typing import Sequence
 
@@ -15,23 +17,70 @@ class PosteriorOutput:
 
 
 class PosteriorEngine:
-    """Minimal posterior engine with mock predictions."""
+    """Online logistic/softmax regression for posterior predictions.
+
+    The engine keeps separate weight matrices for rug probability (binary
+    logistic) and regime probabilities (3-class softmax).  Both models share the
+    first ``n_features`` elements of the input feature vector.
+    """
 
     def __init__(self, n_features: int = 10) -> None:
         self.n_features = n_features
-        self.coefs = np.zeros(n_features)
+        self.w_rug = np.zeros(n_features, dtype=np.float64)
+        self.W_regime = np.zeros((3, n_features), dtype=np.float64)
 
+    # ------------------------------------------------------------------
+    # Prediction
+    # ------------------------------------------------------------------
     def predict(self, x: Sequence[float]) -> PosteriorOutput:
-        """Return dummy probabilities based on a linear score."""
-        score = float(np.dot(self.coefs, x[: self.n_features]))
-        # simple softmax over three regimes
-        logits = np.array([score, -score, 0.0])
+        """Return posterior probabilities for rug and market regimes."""
+
+        feat = np.asarray(x[: self.n_features], dtype=np.float64)
+
+        # Rug probability via logistic regression
+        rug_logit = float(self.w_rug @ feat)
+        rug = 1.0 / (1.0 + np.exp(-rug_logit))
+
+        # Regime probabilities via multinomial logistic (softmax)
+        logits = self.W_regime @ feat
+        logits -= logits.max()  # numerical stability
         exps = np.exp(logits)
         probs = exps / exps.sum()
-        return PosteriorOutput(rug=0.01, trend=probs[0], revert=probs[1], chop=probs[2])
 
-    def update(self, x: Sequence[float], y: float, lr: float = 0.01) -> None:
-        """Perform a simple gradient step on the logistic regression stub."""
-        pred = self.predict(x)
-        error = y - pred.trend
-        self.coefs += lr * error * np.array(x[: self.n_features])
+        return PosteriorOutput(rug=rug, trend=float(probs[0]), revert=float(probs[1]), chop=float(probs[2]))
+
+    # ------------------------------------------------------------------
+    # Online update
+    # ------------------------------------------------------------------
+    def update(self, x: Sequence[float], rug: int, regime: int, lr: float = 0.01) -> None:
+        """Online gradient step for logistic and softmax regressions.
+
+        Parameters
+        ----------
+        x:
+            Feature vector.
+        rug:
+            Observed rug outcome (1 if rug pull occurred else 0).
+        regime:
+            Index of realised regime: 0=trend, 1=revert, 2=chop.
+        lr:
+            Learning rate for gradient descent.
+        """
+
+        feat = np.asarray(x[: self.n_features], dtype=np.float64)
+
+        # Update rug logistic regression
+        rug_pred = 1.0 / (1.0 + np.exp(-(self.w_rug @ feat)))
+        rug_error = rug - rug_pred
+        self.w_rug += lr * rug_error * feat
+
+        # Update regime softmax regression
+        logits = self.W_regime @ feat
+        logits -= logits.max()
+        exps = np.exp(logits)
+        probs = exps / exps.sum()
+        y = np.zeros(3)
+        y[regime] = 1.0
+        error = y - probs
+        self.W_regime += lr * error[:, None] @ feat[None, :]
+

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -9,6 +9,16 @@ def test_posterior_predict_shape():
     assert 0 <= out.revert <= 1
     assert 0 <= out.chop <= 1
     assert abs(out.trend + out.revert + out.chop - 1) < 1e-6
+    assert 0 <= out.rug <= 1
+
+
+def test_posterior_update_learning():
+    eng = PosteriorEngine(n_features=2)
+    x = [1.0, 0.0]
+    before = eng.predict(x).rug
+    eng.update(x, rug=1, regime=0)
+    after = eng.predict(x).rug
+    assert after > before
 
 from solbot.engine import RiskManager
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,7 +1,14 @@
 from fastapi.testclient import TestClient
 
 from solbot.utils import BotConfig
-from solbot.engine import RiskManager, TradeEngine
+from solbot.engine import (
+    RiskManager,
+    TradeEngine,
+    PyFeatureEngine,
+    PosteriorEngine,
+    Event,
+    EventKind,
+)
 from solbot.types import Side
 from solbot.server import create_app
 from solbot.bootstrap import BootstrapCoordinator
@@ -35,6 +42,9 @@ def test_api_order_flow():
     connector = PaperConnector(dal, oracle)
     risk = RiskManager()
     trade = TradeEngine(risk, connector, dal)
+    fe = PyFeatureEngine()
+    fe.update(Event(kind=EventKind.SWAP, amount_in=1.0), slot=1)
+    posterior = PosteriorEngine(n_features=6)
     class DummyAssets(AssetService):
         def refresh(self):
             return self.list_assets()
@@ -43,9 +53,15 @@ def test_api_order_flow():
     assets.dal.save_assets([{"symbol": "SOL"}])
     bootstrap = BootstrapCoordinator()
     os.environ["API_KEY_HASH"] = hashlib.sha256(b"test").hexdigest()
-    app = create_app(cfg, lm, risk, trade, assets, bootstrap)
+    app = create_app(cfg, lm, risk, trade, assets, bootstrap, fe, posterior)
     with TestClient(app) as client:
         assert lm.called
+
+        resp = client.get("/")
+        assert resp.status_code == 200
+        assert "sol-bot dashboard" in resp.text
+        assert "/features" in resp.text
+        assert "/posterior" in resp.text
 
         resp = client.post(
             "/orders",
@@ -61,3 +77,17 @@ def test_api_order_flow():
         assert resp.status_code == 200
         positions = resp.json()
         assert "SOL" in positions
+
+        resp = client.get("/features")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 256
+
+        resp = client.get("/posterior")
+        assert resp.status_code == 200
+        probs = resp.json()
+        assert set(probs) == {"rug", "trend", "revert", "chop"}
+
+        with client.websocket_connect("/features/ws") as ws:
+            fe.update(Event(kind=EventKind.SWAP, amount_in=2.0), slot=1)
+            data = ws.receive_json()
+            assert len(data) == 256


### PR DESCRIPTION
## Summary
- allow feature subscribers to unsubscribe
- surface feature vectors and posterior probabilities via REST and websocket
- add a dashboard landing page with TradingView chart and links to feature and posterior endpoints

## Testing
- `pytest tests/test_engine.py tests/test_features.py tests/test_server.py`

------
https://chatgpt.com/codex/tasks/task_e_68924dfe7b98832ead3afa8a550b1698