### PR TITLE
Return JSON resource index from root endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,24 @@ python -m src.server --wallet YOUR_WALLET --db-path ~/.solbot/state.db
 
 The entrypoint automatically adds ``src`` to ``PYTHONPATH`` so no extra setup is
 required. The server launches a FastAPI app on `http://127.0.0.1:8000` exposing
-endpoints for paper trading and viewing positions. Orders and positions are
+JSON endpoints for dashboards and paper trading. Orders and positions are
 persisted to the SQLite database specified by `--db-path` so the UI remains
 available offline. If ``YOUR_WALLET`` matches the ``LICENSE_AUTHORITY``
 environment variable, the server starts without requiring a license token. Demo
 wallets still start but emit a warning that trading is disabled. The `/status`
 endpoint reports bootstrap progress and `/version` returns the running git
 commit and schema hash.
+
+### Dashboard API
+
+Front-end clients interact with the server via JSON resources and WebSocket feeds:
+
+* `GET /` – resource index with a map of endpoints, TradingView template URL, timestamp, and schema hash
+* `GET /features/schema` – mapping of feature indices to names
+* `GET /dashboard` – consolidated view containing the latest feature vector, posterior probabilities, and open positions
+* `GET /manifest` – machine-readable listing of REST and WebSocket routes
+* `WS /features/ws` – streams objects with `event` metadata and associated `features` array
+* `WS /posterior/ws` – streams posterior probability updates alongside event metadata
 
 ## Configuration
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -116,11 +116,11 @@ def test_pubsub_queue_nonblocking():
     q = fe.subscribe(maxsize=1)
     fe.update(_mk_event(EventKind.SWAP, amount_in=1.0), slot=1)
     assert not q.empty()
-    first = q.get()
+    first_event, first_vec = q.get()
     fe.update(_mk_event(EventKind.SWAP, amount_in=2.0), slot=1)
     assert q.qsize() == 1
-    latest = q.get()
-    assert latest[2] != first[2]
+    latest_event, latest_vec = q.get()
+    assert latest_vec[2] != first_vec[2]
 
 
 def test_unsubscribe_removes_queue():


### PR DESCRIPTION
## Summary
- Serve a JSON resource index at `/` with TradingView template, endpoint map (including new dashboard and manifest routes), timestamp, and schema hash
- Expose `/features/schema` for feature index metadata and stream event context alongside feature vectors over `/features/ws`
- Add posterior WebSocket stream, consolidated `/dashboard` state endpoint, and machine-readable `/manifest`
- Document dashboard API and websocket feeds in README

## Testing
- `pytest tests/test_server.py::test_api_order_flow -q`
- `pytest tests/test_features.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68928a194358832eaa12975484514c7e