### PR TITLE
feat: sync API paths and verify JWTs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -303,3 +303,16 @@
 
 ### Next Steps
 - Improve bootstrap process with configurable token filters.
+
+## OpenAI Assistant - API Path Sync and JWT Verification
+
+**Date:** 2025-08-06
+
+### Summary
+- Replaced hardcoded API paths with FastAPI's `url_path_for` to keep the root index synchronized with router definitions.
+- Extended `/features/schema` with schema hash and timestamp metadata and refreshed Dashboard API docs with authenticated curl examples.
+- Hardened websocket handlers to cancel background tasks cleanly on disconnect.
+- Added real JWT signature and claim verification in the license issuer and introduced the `PyJWT` dependency with supporting tests.
+
+### Next Steps
+- None.

--- a/README.md
+++ b/README.md
@@ -76,11 +76,32 @@ commit and schema hash.
 Front-end clients interact with the server via JSON resources and WebSocket feeds:
 
 * `GET /` – resource index with a map of endpoints, TradingView template URL, timestamp, and schema hash
-* `GET /features/schema` – mapping of feature indices to names
+* `GET /features` – latest normalized feature vector
+* `GET /posterior` – most recent posterior probabilities over market regimes
+* `GET /positions` – open positions *(requires `X-API-Key` header)*
+* `POST /orders` – place paper trade order *(requires `X-API-Key` header)*
+* `GET /features/schema` – mapping of feature indices to names with schema hash and timestamp metadata
 * `GET /dashboard` – consolidated view containing the latest feature vector, posterior probabilities, and open positions
 * `GET /manifest` – machine-readable listing of REST and WebSocket routes
 * `WS /features/ws` – streams objects with `event` metadata and associated `features` array
 * `WS /posterior/ws` – streams posterior probability updates alongside event metadata
+
+Example usage:
+
+```bash
+# fetch latest feature vector
+curl http://127.0.0.1:8000/features
+
+# fetch posterior probabilities
+curl http://127.0.0.1:8000/posterior
+
+# list open positions (API key required)
+curl -H "X-API-Key: $API_KEY" http://127.0.0.1:8000/positions
+
+# place paper trade order (API key required)
+curl -X POST -H "Content-Type: application/json" -H "X-API-Key: $API_KEY" \
+  -d '{"token":"SOL","qty":1,"side":"buy"}' http://127.0.0.1:8000/orders
+```
 
 ## Configuration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,4 +22,5 @@ dependencies = [
     "protobuf>=4.24",
     "pyyaml>=6.0",
     "numpy>=1.21",
+    "PyJWT>=2.8.0",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ ntplib==0.4.0
 protobuf>=4.24
 pyyaml>=6.0
 numpy>=1.21
+PyJWT>=2.8.0

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,33 +1,78 @@
+from datetime import datetime, timedelta, timezone
+import jwt
+
 from fastapi.testclient import TestClient
-from solbot.service.license_issuer import app
+from solbot.service.license_issuer import app, verify_jwt
 from solbot.service import publisher
 
 from solbot.utils.license import LicenseManager
 
 
+def make_token(secret: str, *, exp: timedelta = timedelta(minutes=5)) -> str:
+    payload = {
+        "iss": "issuer",
+        "aud": "audience",
+        "exp": datetime.now(tz=timezone.utc) + exp,
+    }
+    return jwt.encode(payload, secret, algorithm="HS256")
+
+
+def setup_env(monkeypatch, secret: str = "secret"):
+    monkeypatch.setenv("LICENSE_JWT_SECRET", secret)
+    monkeypatch.setenv("LICENSE_JWT_ISSUER", "issuer")
+    monkeypatch.setenv("LICENSE_JWT_AUDIENCE", "audience")
+
+
 def test_issue_endpoint(monkeypatch):
+    setup_env(monkeypatch)
     client = TestClient(app)
     called = {}
 
     def fake_publish(req):
         called.update(req)
 
-    monkeypatch.setattr(publisher, 'publish_issue', fake_publish)
-    resp = client.post('/issue', json={'wallet': 'dest', 'demo': True}, headers={'Authorization': 'Bearer token'})
+    monkeypatch.setattr(publisher, "publish_issue", fake_publish)
+    token = make_token("secret")
+    resp = client.post(
+        "/issue",
+        json={"wallet": "dest", "demo": True},
+        headers={"Authorization": f"Bearer {token}"},
+    )
     assert resp.status_code == 200
-    assert resp.json()['queued'] is True
-    assert called['wallet'] == 'dest'
-    assert called['demo'] is True
+    assert resp.json()["queued"] is True
+    assert called["wallet"] == "dest"
+    assert called["demo"] is True
 
 
 def test_issue_unauthorized(monkeypatch):
+    setup_env(monkeypatch)
     client = TestClient(app)
-    resp = client.post('/issue', json={'wallet': 'dest'}, headers={'Authorization': 'Bearer '})
+    resp = client.post("/issue", json={"wallet": "dest"}, headers={"Authorization": "Bearer "})
     assert resp.status_code == 401
 
 
 def test_healthz(monkeypatch):
     client = TestClient(app)
-    monkeypatch.setattr(LicenseManager, '_client', lambda self: type('C', (), {'is_connected': lambda self: True})())
-    resp = client.get('/healthz')
+    monkeypatch.setattr(
+        LicenseManager, "_client", lambda self: type("C", (), {"is_connected": lambda self: True})()
+    )
+    resp = client.get("/healthz")
     assert resp.status_code == 200
+
+
+def test_verify_jwt_valid(monkeypatch):
+    setup_env(monkeypatch)
+    token = make_token("secret")
+    assert verify_jwt(token) is True
+
+
+def test_verify_jwt_expired(monkeypatch):
+    setup_env(monkeypatch)
+    token = make_token("secret", exp=timedelta(minutes=-5))
+    assert verify_jwt(token) is False
+
+
+def test_verify_jwt_tampered(monkeypatch):
+    setup_env(monkeypatch)
+    token = make_token("wrongsecret")
+    assert verify_jwt(token) is False


### PR DESCRIPTION
## Summary
- generate API root paths via `url_path_for` and expose schema metadata
- validate license JWTs with signatures, claims, and expiration
- document and test dashboard and service flows

## Testing
- `pytest tests/test_service.py tests/test_server.py::test_api_order_flow -q`

------
https://chatgpt.com/codex/tasks/task_e_6892a126eefc832e81178f34b9e4a913