### PR TITLE
Expose full API map for dashboard and enable CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Front-end clients interact with the server via JSON resources and WebSocket feed
 * `GET /features/schema` – mapping of feature indices to names with schema hash and timestamp metadata
 * `GET /dashboard` – consolidated view containing the latest feature vector, posterior probabilities, and open positions
 * `GET /manifest` – machine-readable listing of REST and WebSocket routes
+* `GET /tv` – simple TradingView iframe for manual inspection
 * `WS /features/ws` – streams objects with `event` metadata and associated `features` array
 * `WS /posterior/ws` – streams posterior probability updates alongside event metadata
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -66,6 +66,9 @@ def test_api_order_flow():
             root_data["tradingview"]
             == "https://www.tradingview.com/widgetembed/?symbol=<sym>USDT"
         )
+        assert root_data["endpoints"]["health"] == app.url_path_for("health")
+        assert root_data["endpoints"]["status"] == app.url_path_for("status")
+        assert root_data["endpoints"]["assets"] == app.url_path_for("assets_endpoint")
         assert root_data["endpoints"]["features"] == app.url_path_for("features_endpoint")
         assert (
             root_data["endpoints"]["features_schema"]
@@ -74,10 +77,24 @@ def test_api_order_flow():
         assert root_data["endpoints"]["posterior"] == app.url_path_for("posterior_endpoint")
         assert root_data["endpoints"]["positions"] == app.url_path_for("positions")
         assert root_data["endpoints"]["orders"] == app.url_path_for("orders")
+        assert root_data["endpoints"]["chart"] == app.url_path_for("chart", symbol="<sym>")
+        assert root_data["endpoints"]["version"] == app.url_path_for("version")
+        assert root_data["endpoints"]["docs"] == app.url_path_for("swagger_ui_html")
+        assert root_data["endpoints"]["redoc"] == app.url_path_for("redoc_html")
+        assert root_data["endpoints"]["openapi"] == app.url_path_for("openapi")
+        assert root_data["endpoints"]["metrics"] == app.url_path_for("metrics")
+        assert root_data["endpoints"]["orders_ws"] == app.url_path_for("ws")
+        assert root_data["endpoints"]["features_ws"] == app.url_path_for("features_ws")
+        assert root_data["endpoints"]["posterior_ws"] == app.url_path_for("posterior_ws")
         assert root_data["endpoints"]["dashboard"] == app.url_path_for("dashboard")
         assert root_data["endpoints"]["manifest"] == app.url_path_for("manifest")
+        assert root_data["endpoints"]["tv"] == app.url_path_for("tradingview_page")
         assert "timestamp" in root_data
         assert root_data["schema"] == SCHEMA_HASH
+
+        resp = client.get("/tv")
+        assert resp.status_code == 200
+        assert "<iframe" in resp.text
 
         resp = client.post(
             "/orders",
@@ -154,6 +171,8 @@ def test_api_order_flow():
         assert resp.status_code == 200
         manifest = resp.json()
         ws_paths = manifest["websocket"]
+        assert "/ws" in ws_paths
         assert "/features/ws" in ws_paths and "/posterior/ws" in ws_paths
         rest_paths = [r["path"] for r in manifest["rest"]]
         assert "/dashboard" in rest_paths
+        assert "/tv" in rest_paths


### PR DESCRIPTION
## Summary
- enable CORS on FastAPI server to permit browser clients
- expose complete REST and websocket map in index for frontend hookup
- surface docs, OpenAPI and metrics endpoints for full API discoverability
- type the service map with Pydantic and restore TradingView HTML page
- adjust tests to cover new endpoints and websocket manifest entries

## Testing
- `pytest tests/test_server.py tests/test_config.py tests/test_engine.py tests/test_license.py tests/test_schema.py tests/test_feature_engine.py tests/test_features.py tests/test_data.py tests/test_perf.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6892bd6c908c832e82fed631bd241e0e