### PR TITLE
Replace PEP 604 unions for Python 3.9 compatibility

### DIFF
--- a/src/backtest/runner.py
+++ b/src/backtest/runner.py
@@ -85,8 +85,8 @@ class BacktestRunner:
     def __init__(
         self,
         engine: TradeEngine,
-        fee_model: FeeModel | None = None,
-        slippage_model: SlippageModel | None = None,
+        fee_model: Optional[FeeModel] = None,
+        slippage_model: Optional[SlippageModel] = None,
         initial_cash: float = 0.0,
     ) -> None:
         self.engine = engine

--- a/src/sol_seeker/features/engine.py
+++ b/src/sol_seeker/features/engine.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Tuple, Union
 from .spec import idx
 
 try:  # Attempt to import the compiled rustcore extension.
@@ -25,7 +25,7 @@ class FeatureEngine:
     def __init__(self) -> None:
         self._core = rustcore.FeatureEngine()
 
-    def push_event(self, evt: rustcore.PyEvent | Dict[str, Any]) -> None:
+    def push_event(self, evt: Union[rustcore.PyEvent, Dict[str, Any]]) -> None:
         """Push a parsed event into the engine."""
 
         if isinstance(evt, rustcore.PyEvent):

--- a/src/solbot/server/api.py
+++ b/src/solbot/server/api.py
@@ -164,8 +164,8 @@ def create_app(
     trade: TradeEngine,
     assets: AssetService,
     bootstrap: BootstrapCoordinator,
-    features: FeatureEngine | None = None,
-    posterior: PosteriorEngine | None = None,
+    features: Optional[FeatureEngine] = None,
+    posterior: Optional[PosteriorEngine] = None,
     metrics_interval: float = 0.0,
     ) -> FastAPI:
     app = FastAPI(title="sol-bot API")
@@ -186,7 +186,7 @@ def create_app(
     pos_connections: list[WebSocket] = []
     pos_lock = asyncio.Lock()
     order_subs: list[asyncio.Queue[dict]] = []
-    poller_task: asyncio.Task | None = None
+    poller_task: Optional[asyncio.Task] = None
     runtime_state = {"running": True, "emergency_stop": False, "settings": {}}
 
     def subscribe_orders() -> asyncio.Queue[dict]:
@@ -389,7 +389,7 @@ def create_app(
         return trade.list_positions()
 
     @app.get("/orders")
-    async def orders(status: str | None = Query(None), key: None = Depends(check_key)) -> list[dict]:
+    async def orders(status: Optional[str] = Query(None), key: None = Depends(check_key)) -> list[dict]:
         if not bootstrap.is_ready():
             raise HTTPException(status_code=503, detail="state: BOOTSTRAPPING")
         return [


### PR DESCRIPTION
## Summary
- Replaced `| None` type hints with `Optional` to support Python 3.9
- Updated server, backtest runner, and feature engine to avoid PEP 604 unions

## Testing
- `pytest tests/test_backtest.py tests/test_server.py tests/test_feature_engine.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689611263998832e903eca6685afc43b