### PR TITLE
fix bootstrap event loop

### DIFF
--- a/src/solbot/bootstrap.py
+++ b/src/solbot/bootstrap.py
@@ -3,8 +3,14 @@ from __future__ import annotations
 import asyncio
 from typing import List
 
+
 class BootstrapCoordinator:
     def __init__(self) -> None:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
         self.ready = asyncio.Event()
         self.progress = 0
 


### PR DESCRIPTION
## Summary
- ensure BootstrapCoordinator always creates an event loop when none is running to avoid RuntimeError during init

## Testing
- `pytest tests/test_position_update.py::test_order_triggers_position_update -q`
- `pytest tests/test_server.py::test_api_order_flow -q` (see full suite run)


------
https://chatgpt.com/codex/tasks/task_e_689816ecd204832ea5036ea4bb24c688