### PR TITLE
fix websocket tests

### DIFF
--- a/src/solbot/solana/data.py
+++ b/src/solbot/solana/data.py
@@ -57,7 +57,9 @@ class LogStreamer:
         self._queue_size = queue_size
 
     async def _connect(self) -> AsyncIterator[str]:
-        async with websockets.connect(self.rpc_ws_url) as ws:
+        # Disable environment proxies which can return HTTP 403 for WebSocket
+        # connections (see websockets>=15 default proxy behavior).
+        async with websockets.connect(self.rpc_ws_url, proxy=None) as ws:
             for i, pid in enumerate(self.program_ids, start=1):
                 msg = {
                     "jsonrpc": "2.0",


### PR DESCRIPTION
## Summary
- close unauthorized websocket handshakes before accepting to prevent hangs
- avoid proxy usage in Solana log streamer to prevent HTTP 403 failures
- adjust server tests to close unauthorized websocket sessions without blocking

## Testing
- `pytest tests/test_server.py::test_api_order_flow -vv -s --maxfail=1`
- `pytest -q`
- `timeout 5 python -m src.main --wallet 29xN3QQjDU3U24758y2RSz9L5gxc592BvURyb92rNunF --rpc-ws wss://api.mainnet-beta.solana.com/` *(fails: [Errno 101] Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68982506a914832ebd6ec03ad1aa973d