### PR TITLE
feat: add log websocket feed

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -109,6 +109,7 @@ def test_api_order_flow():
         assert root_data["endpoints"]["posterior_ws"] == app.url_path_for("posterior_ws")
         assert root_data["endpoints"]["positions_ws"] == app.url_path_for("positions_ws")
         assert root_data["endpoints"]["dashboard_ws"] == app.url_path_for("dashboard_ws")
+        assert root_data["endpoints"]["logs_ws"] == app.url_path_for("logs_ws")
         assert root_data["endpoints"]["dashboard"] == app.url_path_for("dashboard")
         assert root_data["endpoints"]["manifest"] == app.url_path_for("manifest")
         assert root_data["endpoints"]["tv"] == app.url_path_for("tradingview_page")

--- a/web/public/openapi.json
+++ b/web/public/openapi.json
@@ -99,9 +99,9 @@
     },
     "/api": {
       "get": {
-        "summary": "API Index",
+        "summary": "Api Index",
         "description": "Return resource index and embed template for TradingView.",
-        "operationId": "api_api_get",
+        "operationId": "api_index_api_get",
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -633,6 +633,10 @@
             "type": "string",
             "title": "Dashboard Ws"
           },
+          "logs_ws": {
+            "type": "string",
+            "title": "Logs Ws"
+          },
           "dashboard": {
             "type": "string",
             "title": "Dashboard"
@@ -676,6 +680,7 @@
           "posterior_ws",
           "positions_ws",
           "dashboard_ws",
+          "logs_ws",
           "dashboard",
           "manifest",
           "tv",

--- a/web/src/api/schema.ts
+++ b/web/src/api/schema.ts
@@ -67,10 +67,10 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * API Index
+         * Api Index
          * @description Return resource index and embed template for TradingView.
          */
-        get: operations["api_api_get"];
+        get: operations["api_index_api_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -399,6 +399,8 @@ export interface components {
             positions_ws: string;
             /** Dashboard Ws */
             dashboard_ws: string;
+            /** Logs Ws */
+            logs_ws: string;
             /** Dashboard */
             dashboard: string;
             /** Manifest */
@@ -647,7 +649,7 @@ export interface operations {
             };
         };
     };
-    api_api_get: {
+    api_index_api_get: {
         parameters: {
             query?: never;
             header?: never;


### PR DESCRIPTION
## Summary
- expose `/logs/ws` websocket endpoint and stream log events
- surface log feed in service map and API schema

## Testing
- `python -m pytest`
- `npx --yes openapi-typescript web/public/openapi.json --output web/src/api/schema.ts`


------
https://chatgpt.com/codex/tasks/task_e_68995775f014832e94161647a3369064