### PR TITLE
fix optional field syntax for legacy Python compatibility

### DIFF
--- a/src/solbot/server/api.py
+++ b/src/solbot/server/api.py
@@ -128,14 +128,14 @@ class PosteriorSnapshot(BaseModel):
 
 
 class NetworkStats(BaseModel):
-    tps: float | None = None
-    fee: float | None = None
+    tps: Optional[float] = None
+    fee: Optional[float] = None
 
 
 class Metrics(BaseModel):
-    cpu: float | None = None
-    memory: float | None = None
-    network: NetworkStats | None = None
+    cpu: Optional[float] = None
+    memory: Optional[float] = None
+    network: Optional[NetworkStats] = None
 
 
 class RouteInfo(BaseModel):


### PR DESCRIPTION
## Summary
- replace 3.10-style `| None` unions with `Optional[...]` in API metrics models to support Python 3.9

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a69565b64832e85ea93a1a547ce51