### PR TITLE
Ensure CopyTrade model works on Python 3.9

### DIFF
--- a/src/solbot/server/api.py
+++ b/src/solbot/server/api.py
@@ -213,7 +213,7 @@ class SmartMoneyFlow(BaseModel):
 
 class CopyTrade(BaseModel):
     whale: str
-    profit: float | None = None
+    profit: Optional[float] = None
 
 
 class StrategyStat(BaseModel):


### PR DESCRIPTION
## Summary
- Replace Python 3.10 union syntax in `CopyTrade` with `Optional` for broader compatibility

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689aa62e78b8832eb54fbfb35813a10a