### PR TITLE
optimize dashboard refresh and default demo to solana

### DIFF
--- a/web/public/dashboard.css
+++ b/web/public/dashboard.css
@@ -2,7 +2,6 @@
         
         body {
             background: radial-gradient(ellipse at center, #1a0a00 0%, #000000 70%);
-            background-attachment: fixed;
         }
         
         .hologram-panel {
@@ -11,7 +10,7 @@
             box-shadow:
                 0 0 10px rgba(255, 140, 0, 0.2),
                 inset 0 0 10px rgba(255, 140, 0, 0.03);
-            backdrop-filter: blur(10px);
+            backdrop-filter: blur(4px);
             position: relative;
         }
         
@@ -27,12 +26,18 @@
             z-index: -1;
             border-radius: inherit;
             opacity: 0.4;
-            animation: borderFlow 12s ease-in-out infinite;
+            animation: borderFlow 30s linear infinite;
         }
-        
+
         @keyframes borderFlow {
             0%, 100% { background-position: 0% 50%; }
             50% { background-position: 100% 50%; }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            .hologram-panel::before {
+                animation: none;
+            }
         }
         
         .amber-glow {

--- a/web/public/dashboard.html
+++ b/web/public/dashboard.html
@@ -88,7 +88,7 @@
                     <div class="w-2 h-2 bg-cyan-glow rounded-full status-online"></div>
                     <span class="text-xs hologram-text cyan-glow">RPC</span>
                     <span id="rpcLatency" class="text-xs hologram-text text-blade-amber">--ms</span>
-                    <div id="rpcTooltip" class="tooltip absolute bottom-full mb-2 px-3 py-2 text-xs rounded">
+                    <div id="rpcTooltip" class="tooltip absolute top-full mt-2 px-3 py-2 text-xs rounded">
                         Solana RPC Connection: Active<br/>
                         Latency: --ms<br/>
                         Last Update: --
@@ -100,7 +100,7 @@
                         <span class="w-2 h-2 bg-cyan-glow rounded-full"></span>
                         <span class="text-xs hologram-text cyan-glow">LIVE</span>
                     </span>
-                    <div class="tooltip absolute bottom-full mb-2 px-3 py-2 text-xs rounded">
+                    <div class="tooltip absolute top-full mt-2 px-3 py-2 text-xs rounded">
                         WebSocket Connection: Streaming<br/>
                         Slot Updates: Live
                     </div>
@@ -111,19 +111,19 @@
             <div class="flex items-center space-x-4">
                 <button class="control-button px-4 py-2 rounded text-xs hologram-text tooltip-trigger relative" id="tradingToggle">
                     ▶ START
-                    <div id="tradingTooltip" class="tooltip absolute bottom-full mb-2 px-3 py-2 text-xs rounded right-0">
+                    <div id="tradingTooltip" class="tooltip absolute top-full mt-2 px-3 py-2 text-xs rounded right-0">
                         Start/Pause Trading Engine
                     </div>
                 </button>
                 <button class="emergency-stop px-4 py-2 rounded text-xs hologram-text tooltip-trigger relative">
                     ⏹ STOP
-                    <div class="tooltip absolute bottom-full mb-2 px-3 py-2 text-xs rounded right-0">
+                    <div class="tooltip absolute top-full mt-2 px-3 py-2 text-xs rounded right-0">
                         Emergency Stop - Close All Positions
                     </div>
                 </button>
                 <button class="control-button px-3 py-2 rounded text-xs hologram-text tooltip-trigger relative" id="settingsToggle">
                     ⚙
-                    <div class="tooltip absolute bottom-full mb-2 px-3 py-2 text-xs rounded right-0">
+                    <div class="tooltip absolute top-full mt-2 px-3 py-2 text-xs rounded right-0">
                         System Health & Settings
                     </div>
                 </button>
@@ -2900,67 +2900,70 @@
         // Update dashboard data from API
         async function updateDashboardData() {
             if (document.hidden) return; // Don't update when tab is hidden
-            
-            try {
-                // Fetch core dashboard data
-                let licenseErr = false;
-                  const [dashboard, positions, orders, featureSnap, posterior, state, security, license] = await Promise.all([
-                      apiClient.getDashboard(),
-                      apiClient.getPositions(),
-                      apiClient.getOrders(),
-                      apiClient.getFeatures(),
-                      apiClient.getPosterior(),
-                      apiClient.getState(),
-                      apiClient.getRiskSecurity().catch(() => null),
-                      apiClient.getLicense().catch(() => { licenseErr = true; return null; })
-                  ]);
 
-                // Update state
+            try {
+                const [dashboard, positions, orders, featureSnap, posterior, state, security] = await Promise.all([
+                    apiClient.getDashboard(),
+                    apiClient.getPositions(),
+                    apiClient.getOrders(),
+                    apiClient.getFeatures(),
+                    apiClient.getPosterior(),
+                    apiClient.getState(),
+                    apiClient.getRiskSecurity().catch(() => null)
+                ]);
+
                 dashboardState.dashboard = dashboard;
                 dashboardState.positions = positions;
                 dashboardState.orders = orders;
                 dashboardState.features = featureSnap?.features;
-                const featureTs = featureSnap?.timestamp;
-                if (Array.isArray(dashboardState.features)) {
-                    updateFeatureStream(dashboardState.features);
-                    renderFeatureSnapshot(dashboardState.features, featureTs);
-                }
                 dashboardState.posterior = posterior;
                 dashboardState.lastUpdate = new Date();
                 dashboardState.state = state;
                 dashboardState.security = security;
-                dashboardState.licenseError = licenseErr;
-                  dashboardState.license = license;
+
                 if (state && state.settings) {
                     applySettings(state.settings);
                 }
-                const mode = state?.mode || license?.mode;
-                dashboardState.isDemo = mode === 'demo';
-                updateLicenseMode(dashboardState.isDemo);
                 tradingActive = !!state?.running;
-                updateTradingButton();
 
+                let assets = null;
                 if (!dashboardState.assets) {
-                    dashboardState.assets = await apiClient.getAssets().catch(() => null);
-                    if (dashboardState.assets) populateAssetSelect(dashboardState.assets);
+                    assets = await apiClient.getAssets().catch(() => null);
+                    if (assets) dashboardState.assets = assets;
                 }
-                updateModePanel();
+                let featureSchema = null;
                 if (!dashboardState.featureSchema) {
-                    dashboardState.featureSchema = await apiClient.getFeaturesSchema().catch(() => null);
-                    if (dashboardState.featureSchema) renderFeatureSchema(dashboardState.featureSchema);
+                    featureSchema = await apiClient.getFeaturesSchema().catch(() => null);
+                    if (featureSchema) dashboardState.featureSchema = featureSchema;
+                }
+                const featureTs = featureSnap?.timestamp;
+
+                const render = () => {
+                    if (assets) populateAssetSelect(assets);
+                    updateModePanel();
+                    if (featureSchema) renderFeatureSchema(featureSchema);
+                    if (Array.isArray(dashboardState.features)) {
+                        updateFeatureStream(dashboardState.features);
+                        renderFeatureSnapshot(dashboardState.features, featureTs);
+                    }
+                    updatePortfolioMetrics();
+                    updateRiskMetrics();
+                    updateSecurityPanel();
+                    void updatePositionsDisplay(positions);
+                    updateSystemHealth();
+                    updateRegimeAnalysis();
+                    updateMarketStats();
+                    const mode = state?.mode || dashboardState.license?.mode;
+                    dashboardState.isDemo = mode === 'demo';
+                    updateLicenseMode(dashboardState.isDemo);
+                    updateTradingButton();
+                };
+                if (typeof requestAnimationFrame === 'function') {
+                    requestAnimationFrame(render);
+                } else {
+                    render();
                 }
 
-                // Update UI components
-                updatePortfolioMetrics();
-                updateRiskMetrics();
-                updateSecurityPanel();
-                await updatePositionsDisplay(positions);
-                updateSystemHealth();
-                updateRegimeAnalysis();
-                updateMarketStats();
-                updateLicenseInfo();
-                  updateLicenseMode(dashboardState.isDemo);
-                
             } catch (error) {
                 console.error('Error updating dashboard data:', error);
                 dashboardState.isDemo = true;
@@ -3717,6 +3720,29 @@
                 }
             }
 
+            async function loadLicense() {
+                if (document.hidden) return;
+                try {
+                    dashboardState.license = await apiClient.getLicense();
+                    dashboardState.licenseError = false;
+                } catch (err) {
+                    console.error('License load failed', err);
+                    dashboardState.license = null;
+                    dashboardState.licenseError = true;
+                }
+                const render = () => {
+                    updateLicenseInfo();
+                    const mode = dashboardState.license?.mode;
+                    dashboardState.isDemo = mode === 'demo';
+                    updateLicenseMode(dashboardState.isDemo);
+                };
+                if (typeof requestAnimationFrame === 'function') {
+                    requestAnimationFrame(render);
+                } else {
+                    render();
+                }
+            }
+
             function updateTrending(tokens) {
               const container = document.getElementById('trendingTokens');
               if (!container) return;
@@ -3917,10 +3943,12 @@
             if (!container) return;
             try {
                 const limit = 1000;
-                let offset = 0;
+                let cursor = null;
                 let allSeries = [];
                 while (true) {
-                    const res = await fetch(`${apiClient.baseURL}/chart/portfolio?tf=${tf}&offset=${offset}&limit=${limit}`, {
+                    const url = new URL(`${apiClient.baseURL}/chart/portfolio?tf=${tf}&limit=${limit}`);
+                    if (cursor !== null) url.searchParams.set('cursor', String(cursor));
+                    const res = await fetch(url.toString(), {
                         headers: apiClient.apiKey ? { 'X-API-Key': apiClient.apiKey } : {}
                     });
                     if (!res.ok) {
@@ -3931,7 +3959,7 @@
                     if (!data.series || data.series.length === 0) break;
                     allSeries = allSeries.concat(data.series);
                     if (data.series.length < limit) break;
-                    offset += limit;
+                    cursor = data.series[data.series.length - 1][0];
                 }
                 if (allSeries.length) {
                     container.innerHTML = '<canvas id="equityCanvas" class="w-full h-full"></canvas>';
@@ -4203,6 +4231,7 @@
                 initializeWebSockets();
 
                 // Initial data fetch
+                    await loadLicense();
                     await updateDashboardData();
                     await loadEquityChart('1H');
                     await loadAnalytics();
@@ -4213,6 +4242,7 @@
                     pollingIntervals.push(setInterval(updateDashboardData, 10000)); // Update every 10 seconds
                     pollingIntervals.push(setInterval(loadAnalytics, 60000));
                     pollingIntervals.push(setInterval(loadCatalysts, 60000));
+                    pollingIntervals.push(setInterval(loadLicense, 300000));
                 pollRpcLatency();
                 pollingIntervals.push(setInterval(pollRpcLatency, 5000));
                 pollSystemStatus();

--- a/web/public/openapi.json
+++ b/web/public/openapi.json
@@ -804,6 +804,15 @@
             "required": false,
             "schema": {
               "type": "integer",
+              "title": "Cursor"
+            },
+            "name": "cursor",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "integer",
               "title": "Limit",
               "default": 1000
             },

--- a/web/src/api/schema.ts
+++ b/web/src/api/schema.ts
@@ -1737,6 +1737,7 @@ export interface operations {
                 start?: number;
                 end?: number;
                 offset?: number;
+                cursor?: number;
                 limit?: number;
             };
             header?: never;

--- a/web/tests/autosave_error.test.ts
+++ b/web/tests/autosave_error.test.ts
@@ -3,84 +3,51 @@
  */
 import { readFileSync } from 'fs';
 import * as path from 'path';
-import { jest } from '@jest/globals';
+import * as vm from 'vm';
 
 test('queueSettingsSave shows toast and re-enables controls on failure', async () => {
   const html = readFileSync(path.join(__dirname, '../public/dashboard.html'), 'utf8');
-  document.documentElement.innerHTML = html;
+  const match = html.match(/let settingsTimer[\s\S]*?const sliders/);
+  expect(match).toBeTruthy();
+  const scriptContent = match![0].replace(/const sliders[\s\S]*$/, '');
 
-  let settingsTimer: any;
-  let isSavingSettings = false;
-  const settingControls = [
-    'maxDrawdown', 'maxPosition', 'maxTrades', 'sniperToggle', 'arbToggle',
-    'mmToggle', 'failoverToggle', 'rpcSelect', 'modeSelect', 'demoCash',
-    'demoAssets', 'saveSettings', 'resetSettings'
-  ];
-
-  function setSettingsDisabled(disabled: boolean) {
-    settingControls.forEach(id => {
-      const el = document.getElementById(id) as HTMLInputElement | null;
-      if (el) el.disabled = disabled;
-    });
-  }
-
-  const toastContainer = document.createElement('div');
-  toastContainer.id = 'toastContainer';
-  document.body.appendChild(toastContainer);
-  const showToast = jest.fn((message: string) => {
-    const toast = document.createElement('div');
-    toast.textContent = message;
-    toastContainer.appendChild(toast);
-  });
-
-  function collectSettings() {
-    return {
-      max_drawdown: parseFloat((document.getElementById('maxDrawdown') as HTMLInputElement).value) / 100,
-      max_position_size: parseFloat((document.getElementById('maxPosition') as HTMLInputElement).value),
-      max_concurrent_trades: parseInt((document.getElementById('maxTrades') as HTMLInputElement).value),
-      strategies: {
-        listing_sniper: (document.getElementById('sniperToggle') as HTMLInputElement).checked,
-        arbitrage: (document.getElementById('arbToggle') as HTMLInputElement).checked,
-        market_making: (document.getElementById('mmToggle') as HTMLInputElement).checked
-      },
-      rpc_provider: (document.getElementById('rpcSelect') as HTMLSelectElement).value,
-      auto_failover: (document.getElementById('failoverToggle') as HTMLInputElement).checked
-    };
-  }
+  document.body.innerHTML = `
+    <input id="maxDrawdown" value="10" />
+    <div id="saveIndicator" class="hidden"></div>
+    <div id="toastContainer"></div>
+  `;
 
   const apiClient = {
-    post: jest.fn(async (_endpoint: string, _data: any) => { throw new Error('save failed'); })
+    post: jest.fn((_e: string, _d: any) => Promise.reject(new Error('fail')))
   };
 
-  function queueSettingsSave() {
-    clearTimeout(settingsTimer);
-    settingsTimer = setTimeout(async () => {
-      if (isSavingSettings) return;
-      isSavingSettings = true;
-      setSettingsDisabled(true);
-      const indicator = document.getElementById('saveIndicator');
-      if (indicator) indicator.classList.remove('hidden');
-      try {
-        await apiClient.post('/state', { settings: collectSettings() });
-      } catch (err) {
-        showToast('Failed to save settings');
-      } finally {
-        if (indicator) indicator.classList.add('hidden');
-        setSettingsDisabled(false);
-        isSavingSettings = false;
-      }
-    }, 500);
-  }
+  jest.useFakeTimers();
+  const context: any = {
+    document,
+    apiClient,
+    localStorage: { getItem: () => null, setItem: () => {} },
+    setTimeout,
+    clearTimeout
+  };
+  vm.createContext(context);
+  const script = new vm.Script(scriptContent);
+  script.runInContext(context);
+  context.showToast = jest.fn((msg: string) => {
+    const toast = document.createElement('div');
+    toast.textContent = msg;
+    document.getElementById('toastContainer')!.appendChild(toast);
+  });
+  context.collectSettings = () => ({ });
 
   const slider = document.getElementById('maxDrawdown') as HTMLInputElement;
+  const indicator = document.getElementById('saveIndicator')!;
 
-  jest.useFakeTimers();
-  queueSettingsSave();
-  jest.advanceTimersByTime(500);
-  expect(slider.disabled).toBe(true);
+  context.queueSettingsSave();
+  await jest.runAllTimersAsync();
   await Promise.resolve();
-
-  expect(showToast).toHaveBeenCalledWith('Failed to save settings');
-  expect(toastContainer.textContent).toContain('Failed to save settings');
+  expect(apiClient.post).toHaveBeenCalledWith('/state', { settings: expect.any(Object) });
+  expect(context.showToast).toHaveBeenCalledWith('Failed to save settings');
+  expect(document.getElementById('toastContainer')!.textContent).toContain('Failed to save settings');
+  expect(indicator.classList.contains('hidden')).toBe(true);
   expect(slider.disabled).toBe(false);
 });

--- a/web/tests/catalyst_list.test.ts
+++ b/web/tests/catalyst_list.test.ts
@@ -77,6 +77,7 @@ test('catalyst list refreshes and clears when empty', async () => {
   const container = document.getElementById('catalystList')!;
   expect(container.children.length).toBe(2);
   expect(container.textContent).toContain('Upgrade');
+  expect(container.textContent).not.toContain('$NOVA');
 
   await loadCatalysts();
   expect(container.textContent).toBe('None');

--- a/web/tests/license_fetch_error.test.ts
+++ b/web/tests/license_fetch_error.test.ts
@@ -7,51 +7,25 @@ import * as vm from 'vm';
 
 test('shows license error when fetch fails', async () => {
   const html = readFileSync(path.join(__dirname, '../public/dashboard.html'), 'utf8');
-  const dashMatch = html.match(/async function updateDashboardData\(\)[\s\S]*?}\n\s*}/);
-  const licMatch = html.match(/function updateLicenseInfo\(\)[\s\S]*?}\n\s*}/);
-  expect(dashMatch).toBeTruthy();
+  const licMatch = html.match(/async function loadLicense\(\)[\s\S]*?}\n\s*}/);
+  const infoMatch = html.match(/function updateLicenseInfo\(\)[\s\S]*?}\n\s*}/);
   expect(licMatch).toBeTruthy();
+  expect(infoMatch).toBeTruthy();
   document.body.innerHTML = '<div id="licenseInfo"><div>WALLET: <span id="licenseWallet"></span></div><div>MODE: <span id="licenseMode"></span></div><div>ISSUED: <span id="licenseIssued"></span></div></div>';
   const context: any = {
     document,
     dashboardState: { assets: null, license: null, licenseError: false, isDemo: false },
     apiClient: {
-      getDashboard: () => Promise.resolve(null),
-      getPositions: () => Promise.resolve(null),
-      getOrders: () => Promise.resolve(null),
-      getFeatures: () => Promise.resolve({ features: [] }),
-      getPosterior: () => Promise.resolve(null),
-      getState: () => Promise.resolve(null),
-      getRiskSecurity: () => Promise.resolve(null),
-      getLicense: () => Promise.reject(new Error('fail')),
-      getCatalysts: () => Promise.resolve(null),
-      getAssets: () => Promise.resolve(null),
-      getFeaturesSchema: () => Promise.resolve(null)
+      getLicense: () => Promise.reject(new Error('fail'))
     },
-    updateFeatureStream: () => {},
-    renderFeatureSnapshot: () => {},
     updateLicenseMode: () => {},
-    updateTradingButton: () => {},
-    populateAssetSelect: () => {},
-    applySettings: () => {},
-    updateModePanel: () => {},
-    renderFeatureSchema: () => {},
-    updatePortfolioMetrics: () => {},
-    updateRiskMetrics: () => {},
-    updateSecurityPanel: () => {},
-    updatePositionsDisplay: () => Promise.resolve(),
-    updateSystemHealth: () => {},
-    updateRegimeAnalysis: () => {},
-    updateMarketStats: () => {},
-    updateCatalystList: () => {},
-    tradingActive: false,
-    licenseInfoTemplate: document.getElementById('licenseInfo')!.innerHTML
+    licenseInfoTemplate: document.getElementById('licenseInfo')!.innerHTML,
+    requestAnimationFrame: (cb: any) => cb()
   };
   vm.createContext(context);
-  const script = new vm.Script(`${dashMatch![0]} ${licMatch![0]}`);
+  const script = new vm.Script(`${licMatch![0]} ${infoMatch![0]}`);
   script.runInContext(context);
-  await context.updateDashboardData();
-  context.updateLicenseInfo();
+  await context.loadLicense();
   const panel = document.getElementById('licenseInfo');
   expect(panel?.textContent).toBe('License data unavailable');
   expect(panel?.classList.contains('text-blade-orange')).toBe(true);

--- a/web/tests/license_panel.test.ts
+++ b/web/tests/license_panel.test.ts
@@ -7,10 +7,10 @@ import * as vm from 'vm';
 
 test('renders license diagnostics panel', async () => {
   const html = readFileSync(path.join(__dirname, '../public/dashboard.html'), 'utf8');
-  const dashMatch = html.match(/async function updateDashboardData\(\)[\s\S]*?}\n\s*}/);
-  const licMatch = html.match(/function updateLicenseInfo\(\)[\s\S]*?}\n\s*}/);
-  expect(dashMatch).toBeTruthy();
+  const licMatch = html.match(/async function loadLicense\(\)[\s\S]*?}\n\s*}/);
+  const infoMatch = html.match(/function updateLicenseInfo\(\)[\s\S]*?}\n\s*}/);
   expect(licMatch).toBeTruthy();
+  expect(infoMatch).toBeTruthy();
 
   document.body.innerHTML = '<div id="licenseInfo"><div>WALLET: <span id="licenseWallet"></span></div><div>MODE: <span id="licenseMode"></span></div><div>ISSUED: <span id="licenseIssued"></span></div></div>';
   const mockLicense = { wallet: 'demoWallet', mode: 'demo', issued_at: 1234567890 };
@@ -18,42 +18,16 @@ test('renders license diagnostics panel', async () => {
     document,
     dashboardState: { assets: null, license: null, licenseError: false, isDemo: false },
     apiClient: {
-      getDashboard: () => Promise.resolve(null),
-      getPositions: () => Promise.resolve(null),
-      getOrders: () => Promise.resolve(null),
-      getFeatures: () => Promise.resolve({ features: [] }),
-      getPosterior: () => Promise.resolve(null),
-      getState: () => Promise.resolve(null),
-      getRiskSecurity: () => Promise.resolve(null),
-      getLicense: () => Promise.resolve(mockLicense),
-      getCatalysts: () => Promise.resolve(null),
-      getAssets: () => Promise.resolve(null),
-      getFeaturesSchema: () => Promise.resolve(null)
+      getLicense: () => Promise.resolve(mockLicense)
     },
-    updateFeatureStream: () => {},
-    renderFeatureSnapshot: () => {},
     updateLicenseMode: () => {},
-    updateTradingButton: () => {},
-    populateAssetSelect: () => {},
-    applySettings: () => {},
-    updateModePanel: () => {},
-    renderFeatureSchema: () => {},
-    updatePortfolioMetrics: () => {},
-    updateRiskMetrics: () => {},
-    updateSecurityPanel: () => {},
-    updatePositionsDisplay: () => Promise.resolve(),
-    updateSystemHealth: () => {},
-    updateRegimeAnalysis: () => {},
-    updateMarketStats: () => {},
-    updateCatalystList: () => {},
-    tradingActive: false,
-    licenseInfoTemplate: document.getElementById('licenseInfo')!.innerHTML
+    licenseInfoTemplate: document.getElementById('licenseInfo')!.innerHTML,
+    requestAnimationFrame: (cb: any) => cb()
   };
   vm.createContext(context);
-  const script = new vm.Script(`${dashMatch![0]} ${licMatch![0]}`);
+  const script = new vm.Script(`${licMatch![0]} ${infoMatch![0]}`);
   script.runInContext(context);
-  await context.updateDashboardData();
-  context.updateLicenseInfo();
+  await context.loadLicense();
   expect(document.getElementById('licenseWallet')?.textContent).toBe(mockLicense.wallet);
   expect(document.getElementById('licenseMode')?.textContent).toBe(mockLicense.mode);
   const issuedText = new Date(mockLicense.issued_at * 1000).toLocaleString();


### PR DESCRIPTION
## Summary
- document performance profiling methodology and bottlenecks
- paginate and downsample equity history API with frontend cursor fetching
- add autosave failure path test
- seed demo mode with SOL capital and pre-populated positions
- lighten dashboard background animation and position header tooltips within viewport

## Testing
- `npm test`
- `pytest tests/test_server.py::test_demo_defaults_sol_asset tests/test_server.py::test_chart_portfolio_cursor_pagination tests/test_server.py::test_chart_portfolio_pagination tests/test_server.py::test_chart_portfolio_downsample tests/test_server.py::test_chart_portfolio_invalid_limit tests/test_server.py::test_chart_portfolio_start_after_end`


------
https://chatgpt.com/codex/tasks/task_e_689e3e56127c832eb1ace488fb7b0984