### PR TITLE
feat: add basic walkthrough and robust regime ws

### DIFF
--- a/AGENTS-AUDIT.md
+++ b/AGENTS-AUDIT.md
@@ -30,27 +30,40 @@ This file defines the immediate and near-term directives for the next developmen
 ## Progress 2025-08-19
 - Removed atmospheric background from dashboard to reduce CPU usage and added shared footer/disclaimer includes.
 
+## Progress 2025-08-20
+- Defaulted engine to paused demo mode with 10 SOL paper balance and live USD conversion on load.
+- Replaced static portfolio sparkline with Chart.js fetching `/chart/portfolio` and refreshed on WebSocket updates.
+- Applied SOL/USD formatter across modules and migrated system status metrics to Settings.
+
+## Progress 2025-08-21
+- Persist PyFeatureEngine and PosteriorEngine state under `~/.solbot/models/`, autosaving every 5 minutes and loading on startup.
+- Expanded `/risk/portfolio` to provide equity, PnL change, and position metrics for live dashboard updates.
+
+## Progress 2025-08-22
+- Added `/strategy/performance_matrix` with 7d/30d windows and wired dashboard heatmap, breakdown, and risk metrics.
+- Replaced backtesting sliders with numeric/date inputs and streamed results from `/backtest/ws/{id}`.
+- Consolidated feature panes into a single collapsible **AI Diagnostics** section and added log filter buttons to the debug console.
+- Reordered `settings.html`, introduced primary asset selector, time‑zone dropdown, and persisted form controls to `/state` and `localStorage`.
+
+## Progress 2025-08-23
+- Added basic/advanced dashboard modes with first-use selector and class-based panel hiding.
+- Introduced background animation toggle; setting saves to `/state` and applies `no-anim` class.
+- Rug pull detector now checks liquidity, owner withdrawals, and mint revocations with `/risk/rug` endpoint and tests.
+
+## Progress 2025-08-24
+- Regime analysis panel now retries `/posterior/ws` with exponential backoff and hides after all attempts fail.
+- Basic-mode walkthrough added; selecting Basic mode triggers a one-time guided tour across key dashboard panels.
+
+## Progress 2025-08-25
+- Added theme selector (Seeker, Dark, Light) with static backgrounds for non-Seeker modes and slower glow animation.
+- Engine start/stop endpoints now return HTTP 409 on conflicting requests with dashboard toasts reflecting the state.
+
 ## User Vision & Dashboard Overhaul Backlog (2025-08-09)
 
 The following directives capture a comprehensive UX and functionality review from the project owner. Treat every bullet as a blocking issue. Remove placeholder data and wire all modules to real-time backend or hide them. Default everything to Solana-centric metrics with live SOL→USD conversions.
 
 ### 1. Initial State & Global Layout
-- **Default mode:** Demo with 10 SOL starting balance; show equivalent USD (no `+10 SOL` prefix).
-  - Modify `web/public/dashboard.html` around the settings form to seed `demoCapital` with `10` and immediately render `10 SOL ($<spot USD>)`.
-  - Fetch SOL price from `/market/solusd` on load and cache for conversions.
-- **Engine toggle:** Dashboard loads in `paused` state. User presses `START` to begin. `PAUSE` always stops trading.
-  - In `web/public/dashboard.html` (lines ~100, ~1935), set `running=false` on init and ensure the button text reads `▶ START`.
-  - Backend (`src/server.py`) must not auto-start trading loops when `--wallet` is provided; require explicit `/state` POST.
-- **Top bar:** Only display `LIVE`/`DEMO` mode, RPC latency, and hamburger for side menu. Move clock into settings. Remove “WS DISCONNECTED”.
-  - Delete the `#wsStatus` span in `dashboard.html` and relocate the clock element into the settings panel header.
-  - Add `id="rpcLatency"` span fed by `/health` and `id="modeIndicator"` derived from `/state`.
-- **Responsive design:** Only “Portfolio Value” and “Realized P&L” may sit side‑by‑side on large screens. All other modules stack vertically and scale cleanly across mobile → 4 K. Test both portrait and landscape.
-  - Refactor `dashboard.css` to use a single-column flex layout below 1280 px and explicit `md:grid-cols-2` only for the top metrics.
-  - Verify layout manually in Chrome dev tools for iPhone SE, iPad, and 4 K monitor presets.
-- **Side menu:** Add a left‑side hamburger button revealing navigation links. Sections: Dashboard, Whale Tracker, Strategies (includes AI Backtesting Lab), MEV Shield & Alpha Signals, Social Sentiment Matrix, Settings. Menu must slide in/out smoothly and be obvious on all viewports.
-  - Implement `#sideMenu` off‑canvas panel in `dashboard.html` with Tailwind `translate-x` transitions and overlay.
-  - Each link should route via `window.location` to `dashboard.html`, `whales.html`, `strategies.html`, `mev.html`, `sentiment.html`, and `settings.html` respectively.
-  - Ensure hamburger button (`#menuToggle`) remains accessible at <768 px.
+*(Completed: default demo mode, engine toggle, top bar cleanup, responsive grid, accessible side menu)*
 
 ### 2. Top Metrics Panel
 - **Realized P&L card:** Format `+0.00 SOL ($0.00)` and a second line `+0.00 SOL TODAY ($0.00)`.
@@ -66,16 +79,7 @@ The following directives capture a comprehensive UX and functionality review fro
   <!-- Completed: canvas mini-map subscribes to `/positions/ws` and draws bar per trade -->
 
 ### 3. Module Ordering & Removal
-- Remove **Backtest P&L** and **System Status** from main dashboard. Surface uptime/resource usage within Settings instead.
-  - Delete sections `#backtestPnl` and `#systemStatus` from `dashboard.html` (lines ~700 and ~900).
-  - In `settings.html`, create `#resourceUsage` card showing CPU, RAM, and uptime fetched from `/metrics`.
-- Module order after the top metrics:
-  1. Realized P&L
-  2. Open Positions
-  3. Portfolio Equity Curve / P&L Breakdown / Market Data / Regime Analysis (tabbed)
-  4. Portfolio & Positions
-  5. Portfolio Risk
-  6. (Navigation to other pages: Whale Tracker, Neural Strategy Matrix & other AI integrations, Strategies/Backtesting, MEV Shield & Alpha Signals, Social Sentiment Matrix)
+*(Completed: Backtest P&L and System Status moved to settings; dashboard modules reordered)*
 
 ### 4. Equity Curve / P&L / Market Data / Regime Analysis Tabs
 - **Tab styling:** The active tab text is normal; inactive tabs are highlighted. Clicking a tab loads its content and removes highlight from current tab.
@@ -636,6 +640,19 @@ Completion of these steps establishes the continuous data backbone and decision 
    - Add structured logs with correlation IDs for end-to-end tracing.
 5. Automate CI.
    - Ensure linting, tests, and type checks run on every push; block merges on failure.
+
+## OpenAI Assistant - Persistence & Rug Detector
+
+**Date:** 2025-08-19
+
+### Summary
+- Engine now loads feature and posterior models from `~/.solbot/models/` on startup and saves checkpoints every five minutes.
+- Token launch scanner and feature/posterior streams start immediately, warming state before any trading commands.
+- Added lightweight `RugDetector` with `/risk/rug` endpoint and dashboard polling for real-time alerts.
+
+### Next Steps
+- Tune rug heuristics using live liquidity and ownership data.
+- Expand model serialization with versioning and atomic writes.
 
 ## 12. Long-Term Enhancements
 1. Reinforcement learning policy updates.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -676,3 +676,41 @@ All files reside at the repository root unless a path is shown.
 
 ### Next Steps
 - Expand settings form controls (drawdown slider, position units, RPC presets) and gate dashboard panels by basic/advanced mode.
+
+## OpenAI Assistant - Strategy Matrix & Backtesting Lab
+
+**Date:** 2025-08-22
+
+### Summary
+- Exposed `/strategy/performance_matrix` and wired the dashboard heatmap, strategy breakdown, and risk metrics with 7D/30D toggles.
+- Overhauled the AI Backtesting Lab with numeric inputs and date pickers, streaming results from `/backtest/ws/{id}` and formatting via shared SOL helpers.
+- Consolidated feature panels into a collapsible "AI Diagnostics" section and added log filters plus a Generate button to the debug console.
+- Reordered `settings.html`, added a primary asset datalist and time-zone selector, and persisted values to `/state` and `localStorage`.
+
+### Next Steps
+- Expand memecoin sentiment collectors and refine strategy modules with live metrics.
+
+## OpenAI Assistant - Strategy Modules & Rug Detection
+
+**Date:** 2025-08-23
+
+### Summary
+- Added lightweight Sniper, Arbitrage, and Market Making strategy stubs under `src/solbot/strategy/` with configuration hooks.
+- Introduced basic vs. advanced dashboard modes with first-use modal and `advanced` class hiding.
+- Enhanced `RugDetector` to flag liquidity pulls, owner withdrawals, and mint revocations; exposed via `/risk/rug` with tests.
+- Footer link updated to new repository and shared across all public pages with disclaimer.
+
+### Next Steps
+- Flesh out strategy algorithms with live market data and connect toggles to runtime enabling/disabling.
+
+## OpenAI Assistant - Theme Selector & Engine Conflicts
+
+**Date:** 2025-08-25
+
+### Summary
+- Added Light/Dark/Seeker theme selector with persistent storage and global application via utility script.
+- Disabled atmospheric glow for non-Seeker themes and slowed animation for reduced CPU load.
+- Enforced engine start/stop state conflicts, returning HTTP 409 with dashboard toasts.
+
+### Next Steps
+- Expand light/dark palettes across panels and monitor animation performance.

--- a/src/solbot/engine/features.py
+++ b/src/solbot/engine/features.py
@@ -282,6 +282,27 @@ class PyFeatureEngine(FeatureEngine):
         self.last_touched.fill(0)
         self._decay_slot = -1
 
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
+    def save(self, path: str | Path) -> None:
+        np.savez(
+            path,
+            curr=self.curr,
+            prev1=self.prev1,
+            prev2=self.prev2,
+            mean=self.mean,
+            var=self.var,
+        )
+
+    def load(self, path: str | Path) -> None:
+        data = np.load(path)
+        self.curr = data["curr"]
+        self.prev1 = data["prev1"]
+        self.prev2 = data["prev2"]
+        self.mean = data["mean"]
+        self.var = data["var"]
+
     def _decay_inactive(self, slot: int) -> None:
         delta = slot - self.last_touched
         mask = delta > 0

--- a/src/solbot/engine/posterior.py
+++ b/src/solbot/engine/posterior.py
@@ -3,6 +3,7 @@
 """Lightweight online posterior models for rug and regime probabilities."""
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Sequence
 
 import numpy as np
@@ -28,6 +29,21 @@ class PosteriorEngine:
         self.n_features = n_features
         self.w_rug = np.zeros(n_features, dtype=np.float64)
         self.W_regime = np.zeros((3, n_features), dtype=np.float64)
+
+    # ------------------------------------------------------------------
+    # Persistence helpers
+    # ------------------------------------------------------------------
+    def save(self, path: str | Path) -> None:
+        np.savez(path, w_rug=self.w_rug, W_regime=self.W_regime)
+
+    @classmethod
+    def load(cls, path: str | Path) -> "PosteriorEngine":
+        data = np.load(path)
+        n_features = len(data["w_rug"])
+        inst = cls(n_features)
+        inst.w_rug = data["w_rug"]
+        inst.W_regime = data["W_regime"]
+        return inst
 
     # ------------------------------------------------------------------
     # Prediction

--- a/src/solbot/persistence/dal.py
+++ b/src/solbot/persistence/dal.py
@@ -51,7 +51,9 @@ class DAL:
     """Handle SQLite persistence."""
 
     def __init__(self, path: str) -> None:
-        os.makedirs(os.path.dirname(path), exist_ok=True)
+        dir_path = os.path.dirname(path)
+        if dir_path:
+            os.makedirs(dir_path, exist_ok=True)
         self.engine = create_engine(
             f"sqlite:///{path}", connect_args={"check_same_thread": False}
         )

--- a/src/solbot/risk/__init__.py
+++ b/src/solbot/risk/__init__.py
@@ -1,0 +1,3 @@
+from .rug_detector import RugDetector, RugAlert
+
+__all__ = ["RugDetector", "RugAlert"]

--- a/src/solbot/risk/rug_detector.py
+++ b/src/solbot/risk/rug_detector.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+
+@dataclass
+class RugAlert:
+    token: str
+    reason: str
+
+
+class RugDetector:
+    """Basic heuristics for detecting potential rug pulls.
+
+    The detector consumes simplified token events with the following optional
+    boolean/float keys:
+
+    - ``liquidity_removed``: fraction of pool liquidity pulled.
+    - ``owner_withdraw``: token owner withdrew funds.
+    - ``mint_paused``: mint authority revoked or paused.
+
+    If any of these exceed conservative thresholds the detector records an
+    alert for the token.  The design favours readability over exhaustive
+    on-chain coverage so unit tests can exercise common rug patterns easily.
+    """
+
+    def __init__(self) -> None:
+        self._alerts: Dict[str, RugAlert] = {}
+
+    def update(self, event: Dict) -> None:
+        token = event.get("token")
+        if not token:
+            return
+        # Large fraction of liquidity yanked from the pool
+        if event.get("liquidity_removed", 0.0) > 0.5:
+            self._alerts[token] = RugAlert(token, "liquidity removed")
+        # Owner suddenly withdrawing funds
+        if event.get("owner_withdraw"):
+            self._alerts[token] = RugAlert(token, "owner withdrawal")
+        # Mint authority paused or burned
+        if event.get("mint_paused"):
+            self._alerts[token] = RugAlert(token, "mint authority revoked")
+
+    def alerts(self) -> List[RugAlert]:
+        return list(self._alerts.values())
+
+    def reset(self) -> None:
+        self._alerts.clear()

--- a/src/solbot/scanner/__init__.py
+++ b/src/solbot/scanner/__init__.py
@@ -1,0 +1,5 @@
+"""Scanner package for monitoring chain-wide token launches."""
+
+from .launch import TokenLaunchScanner
+
+__all__ = ["TokenLaunchScanner"]

--- a/src/solbot/scanner/launch.py
+++ b/src/solbot/scanner/launch.py
@@ -1,0 +1,34 @@
+import asyncio
+import contextlib
+from typing import Optional
+
+
+class TokenLaunchScanner:
+    """Background task that watches for new token launches.
+
+    This is a lightweight placeholder implementation used for integration
+    testing. The real scanner would connect to on-chain sources and emit
+    events whenever a new memecoin launches.
+    """
+
+    def __init__(self) -> None:
+        self._task: Optional[asyncio.Task] = None
+
+    async def _run(self) -> None:
+        try:
+            while True:
+                await asyncio.sleep(1)
+        except asyncio.CancelledError:
+            pass
+
+    def start(self) -> None:
+        if self._task is None or self._task.done():
+            loop = asyncio.get_event_loop()
+            self._task = loop.create_task(self._run())
+
+    async def stop(self) -> None:
+        if self._task is not None:
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+            self._task = None

--- a/src/solbot/social/__init__.py
+++ b/src/solbot/social/__init__.py
@@ -1,0 +1,26 @@
+"""Social sentiment collectors for Sol Seeker.
+
+This package provides lightweight parsers and async helpers to gather
+mentions of Solana tokens from various social platforms. The collectors
+expose a common :class:`TokenMention` data structure so the server can
+aggregate counts regardless of the source (Twitter, Telegram, etc.).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import time
+
+
+@dataclass
+class TokenMention:
+    """Represents a single token mention from a social message."""
+
+    symbol: str
+    user: str
+    sentiment: float
+    timestamp: float
+
+    @classmethod
+    def from_parts(cls, symbol: str, user: str, sentiment: float) -> "TokenMention":
+        return cls(symbol=symbol.upper(), user=user, sentiment=sentiment, timestamp=time.time())

--- a/src/solbot/social/telegram.py
+++ b/src/solbot/social/telegram.py
@@ -1,0 +1,25 @@
+"""Minimal Telegram collector for token mentions.
+
+Similar to :mod:`solbot.social.twitter`, this module exposes a coroutine
+that parses an async iterator of Telegram-style messages.  The function is
+framework agnostic so tests can supply their own iterators.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from collections.abc import AsyncIterator
+from . import TokenMention
+
+TOKEN_PATTERN = re.compile(r"\$([A-Z]{2,10})")
+
+
+async def stream_mentions(source: AsyncIterator[dict], queue: asyncio.Queue[TokenMention]) -> None:
+    """Consume ``source`` async iterator of Telegram messages and push mentions."""
+    async for msg in source:
+        text = msg.get("text", "")
+        user = msg.get("user", "")
+        sentiment = float(msg.get("sentiment", 0))
+        for match in TOKEN_PATTERN.findall(text):
+            await queue.put(TokenMention.from_parts(match, user, sentiment))

--- a/src/solbot/social/twitter.py
+++ b/src/solbot/social/twitter.py
@@ -1,0 +1,31 @@
+"""Minimal Twitter collector for token mentions.
+
+This module doesn't hit the real Twitter API but exposes a coroutine that
+can parse an async iterator of tweet-like objects.  It is primarily meant
+for tests and local demos where a queue of messages is provided.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from collections.abc import AsyncIterator
+from . import TokenMention
+
+TOKEN_PATTERN = re.compile(r"\$([A-Z]{2,10})")
+
+
+async def stream_mentions(source: AsyncIterator[dict], queue: asyncio.Queue[TokenMention]) -> None:
+    """Consume ``source`` async iterator of tweets and push token mentions.
+
+    Each item in ``source`` is expected to be a mapping with ``text``,
+    ``user`` and optional ``sentiment`` fields.  For every ``$TOKEN`` symbol
+    found in the text a :class:`TokenMention` is added to ``queue``.
+    """
+
+    async for tweet in source:
+        text = tweet.get("text", "")
+        user = tweet.get("user", "")
+        sentiment = float(tweet.get("sentiment", 0))
+        for match in TOKEN_PATTERN.findall(text):
+            await queue.put(TokenMention.from_parts(match, user, sentiment))

--- a/src/solbot/strategy/__init__.py
+++ b/src/solbot/strategy/__init__.py
@@ -1,0 +1,11 @@
+"""Strategy modules for specific trading approaches."""
+
+from .sniper import SniperStrategy
+from .arbitrage import ArbitrageStrategy
+from .market_making import MarketMakingStrategy
+
+__all__ = [
+    "SniperStrategy",
+    "ArbitrageStrategy",
+    "MarketMakingStrategy",
+]

--- a/src/solbot/strategy/arbitrage.py
+++ b/src/solbot/strategy/arbitrage.py
@@ -1,0 +1,24 @@
+"""Simple cross-exchange arbitrage stub."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from .typing import RiskManagerLike
+
+
+@dataclass
+class ArbOpportunity:
+    spread: float
+    latency_ms: int
+
+
+class ArbitrageStrategy:
+    def __init__(self, risk: RiskManagerLike, max_latency: int = 100) -> None:
+        self.risk = risk
+        self.max_latency = max_latency
+
+    def should_trade(self, opp: ArbOpportunity, fee: float) -> bool:
+        return opp.spread > fee and opp.latency_ms < self.max_latency
+
+    def size(self, equity: float, fraction: float = 0.05) -> float:
+        return equity * fraction

--- a/src/solbot/strategy/market_making.py
+++ b/src/solbot/strategy/market_making.py
@@ -1,0 +1,24 @@
+"""Naive market making strategy providing bids and asks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from .typing import RiskManagerLike
+
+
+@dataclass
+class Quote:
+    price: float
+    size: float
+
+
+class MarketMakingStrategy:
+    def __init__(self, risk: RiskManagerLike, spread: float = 0.002) -> None:
+        self.risk = risk
+        self.spread = spread
+
+    def quotes(self, mid: float) -> tuple[Quote, Quote]:
+        size = self.risk.equity * 0.01 / mid
+        bid = Quote(price=mid * (1 - self.spread), size=size)
+        ask = Quote(price=mid * (1 + self.spread), size=size)
+        return bid, ask

--- a/src/solbot/strategy/sniper.py
+++ b/src/solbot/strategy/sniper.py
@@ -1,0 +1,24 @@
+"""Listing sniper that buys immediately on new token listings."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from .typing import RiskManagerLike
+
+
+@dataclass
+class SniperConfig:
+    max_slippage: float = 0.01
+    stake: float = 0.1  # fraction of equity
+
+
+class SniperStrategy:
+    def __init__(self, risk: RiskManagerLike, cfg: SniperConfig | None = None) -> None:
+        self.risk = risk
+        self.cfg = cfg or SniperConfig()
+
+    def should_buy(self, price_impact: float) -> bool:
+        return price_impact <= self.cfg.max_slippage
+
+    def size(self, equity: float) -> float:
+        return equity * self.cfg.stake

--- a/src/solbot/strategy/typing.py
+++ b/src/solbot/strategy/typing.py
@@ -1,0 +1,5 @@
+from typing import Protocol
+
+
+class RiskManagerLike(Protocol):
+    equity: float

--- a/src/solbot/utils/__init__.py
+++ b/src/solbot/utils/__init__.py
@@ -14,7 +14,10 @@ try:
     from ..service.license_issuer import app as license_issuer_app
 except Exception:  # pragma: no cover
     license_issuer_app = None
-from ..server import create_app as create_trading_app
+try:  # pragma: no cover - avoid circular import during tests
+    from ..server import create_app as create_trading_app
+except Exception:  # pragma: no cover
+    create_trading_app = None
 
 __all__ = [
     "BotConfig",

--- a/src/solbot/utils/config.py
+++ b/src/solbot/utils/config.py
@@ -39,6 +39,11 @@ def parse_args(args: Optional[List[str]] = None) -> argparse.Namespace:
         action="store_true",
         help="Run bootstrap process then exit",
     )
+    parser.add_argument(
+        "--auto-start",
+        action="store_true",
+        help="Start engine immediately without waiting for user input",
+    )
     ns = parser.parse_args(args)
     if ns.rpc_http is None:
         ns.rpc_http = ns.rpc_ws.replace("wss", "https").replace("ws", "http")
@@ -53,6 +58,7 @@ class BotConfig:
     wallet: str
     db_path: str
     bootstrap: bool = False
+    auto_start: bool = False
 
     @classmethod
     def from_args(cls, args: argparse.Namespace) -> "BotConfig":
@@ -63,4 +69,5 @@ class BotConfig:
             wallet=args.wallet,
             db_path=args.db_path,
             bootstrap=args.bootstrap,
+            auto_start=getattr(args, "auto_start", False),
         )

--- a/tests/test_backtest_ws_close.py
+++ b/tests/test_backtest_ws_close.py
@@ -1,0 +1,82 @@
+import csv
+import tempfile
+import pytest
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+from prometheus_client import REGISTRY
+
+from solbot.utils import BotConfig
+from solbot.engine import RiskManager, TradeEngine
+from solbot.bootstrap import BootstrapCoordinator
+from solbot.persistence import DAL
+from solbot.persistence.assets import AssetService
+from solbot.exchange import PaperConnector
+from solbot.oracle.coingecko import PriceOracle
+from solbot.server import create_app
+
+
+class DummyLM:
+    def license_mode(self, wallet: str) -> str:
+        return "full"
+
+
+def create_test_app() -> TestClient:
+    for collector in list(REGISTRY._collector_to_names.keys()):
+        REGISTRY.unregister(collector)
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    cfg = BotConfig(
+        rpc_ws="ws://localhost:8900",
+        rpc_http="http://localhost:8900",
+        log_level="INFO",
+        wallet="111",
+        db_path=tmp.name,
+        bootstrap=False,
+    )
+    lm = DummyLM()
+    dal = DAL(cfg.db_path)
+
+    class DummyOracle(PriceOracle):
+        async def price(self, token: str) -> float:  # type: ignore[override]
+            return 1.0
+
+        async def volume(self, token: str) -> float:  # type: ignore[override]
+            return 1_000.0
+
+    oracle = DummyOracle()
+    connector = PaperConnector(dal, oracle)
+    risk = RiskManager()
+    trade = TradeEngine(risk, connector, dal)
+    bootstrap = BootstrapCoordinator()
+
+    class DummyAssets(AssetService):
+        def refresh(self):
+            return self.list_assets()
+
+    assets = DummyAssets(dal)
+    assets.dal.save_assets([{"symbol": "SOL"}])
+    app = create_app(cfg, lm, risk, trade, assets, bootstrap)
+    return TestClient(app)
+
+
+def test_backtest_ws_close(tmp_path):
+    csv_path = tmp_path / "data.csv"
+    with csv_path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=["timestamp", "price", "volume"])
+        writer.writeheader()
+        writer.writerow({"timestamp": 1, "price": 100, "volume": 0})
+        writer.writerow({"timestamp": 2, "price": 110, "volume": 0})
+    with create_test_app() as client:
+        resp = client.post(
+            "/backtest",
+            json={"period": str(csv_path), "capital": 0.0, "strategy_mix": "momentum"},
+        )
+        assert resp.status_code == 200
+        job_id = resp.json()["id"]
+        with client.websocket_connect(f"/backtest/ws/{job_id}") as ws:
+            while True:
+                msg = ws.receive_json()
+                if msg.get("finished"):
+                    assert "pnl" in msg
+                    break
+            with pytest.raises(WebSocketDisconnect):
+                ws.receive_text()

--- a/tests/test_mev_alpha_endpoints.py
+++ b/tests/test_mev_alpha_endpoints.py
@@ -1,0 +1,28 @@
+from fastapi.testclient import TestClient
+
+from tests.test_price_endpoint import build_app
+
+
+def test_mev_alpha_endpoints():
+    app = build_app()
+    with TestClient(app) as client:
+        mev = client.get("/mev/status")
+        assert mev.status_code == 200
+        data = mev.json()
+        assert {
+            "saved_today",
+            "attacks_blocked",
+            "success_rate",
+            "latency_ms",
+        } <= data.keys()
+
+        alpha = client.get("/alpha/signals")
+        assert alpha.status_code == 200
+        a = alpha.json()
+        assert {
+            "strength",
+            "social_sentiment",
+            "onchain_momentum",
+            "whale_activity",
+        } <= a.keys()
+

--- a/tests/test_sentiment_endpoints.py
+++ b/tests/test_sentiment_endpoints.py
@@ -1,0 +1,28 @@
+import pytest
+from sqlmodel import SQLModel
+from httpx import AsyncClient
+
+
+@pytest.fixture(scope="module")
+def test_app():
+    SQLModel.metadata.clear()
+    from src.solbot.server.api import app
+    return app
+
+
+@pytest.mark.asyncio
+async def test_sentiment_pulse_and_influencers(test_app):
+    async with AsyncClient(app=test_app, base_url="http://test") as ac:
+        pulse = await ac.get("/sentiment/pulse")
+        inf = await ac.get("/sentiment/influencers")
+        trending = await ac.get("/sentiment/trending")
+    assert pulse.status_code == 200
+    assert inf.status_code == 200
+    assert trending.status_code == 200
+    data = pulse.json()
+    assert "fear_greed" in data
+    infl = inf.json()
+    assert isinstance(infl, list) and len(infl) > 0
+    trend = trending.json()
+    symbols = {t["symbol"] for t in trend}
+    assert "BONK" in symbols

--- a/tests/test_strategy_matrix_endpoint.py
+++ b/tests/test_strategy_matrix_endpoint.py
@@ -1,24 +1,17 @@
 import tempfile
 from fastapi.testclient import TestClient
 
+import tempfile
+from fastapi.testclient import TestClient
+
 from solbot.utils import BotConfig
 from solbot.engine import RiskManager, TradeEngine, PyFeatureEngine, PosteriorEngine
 from solbot.server import create_app
-import solbot.server.api as api_module
 from solbot.persistence import DAL
 from solbot.persistence.assets import AssetService
 from solbot.exchange import PaperConnector
 from solbot.oracle.coingecko import PriceOracle
 from solbot.bootstrap import BootstrapCoordinator
-from prometheus_client import REGISTRY
-
-
-def _clear_registry() -> None:
-    for collector in list(REGISTRY._collector_to_names.keys()):
-        try:
-            REGISTRY.unregister(collector)
-        except KeyError:
-            pass
 
 
 class DummyLM:
@@ -35,7 +28,6 @@ class DummyOracle(PriceOracle):
 
 
 def build_app():
-    _clear_registry()
     tmp = tempfile.NamedTemporaryFile(delete=False)
     cfg = BotConfig(
         rpc_ws="ws://localhost:8900",
@@ -56,28 +48,14 @@ def build_app():
     assets = AssetService(dal)
     bootstrap = BootstrapCoordinator()
     app = create_app(cfg, lm, risk, trade, assets, bootstrap, fe, posterior)
-    api_module.oracle = connector.oracle
-    return app, risk
+    return app
 
 
-def test_risk_portfolio_endpoint():
-    app, risk = build_app()
-    risk.update_equity(100.0)
+def test_strategy_matrix_endpoint():
+    app = build_app()
     with TestClient(app) as client:
-        resp = client.get("/risk/portfolio")
+        resp = client.get("/strategy/matrix")
         assert resp.status_code == 200
         data = resp.json()
-        assert {"equity", "change", "change_pct", "max_drawdown", "leverage", "exposure", "position_size"} <= data.keys()
-
-
-def test_risk_portfolio_exposure_ratio():
-    app, risk = build_app()
-    risk.update_equity(100.0)
-    risk.add_position("SOL", qty=1.0, price=10.0)
-    risk.update_equity(100.0)
-    with TestClient(app) as client:
-        resp = client.get("/risk/portfolio")
-        assert resp.status_code == 200
-        data = resp.json()
-        expected = risk.total_exposure() / risk.equity
-        assert data["exposure"] == expected
+        assert isinstance(data, list)
+        assert data and "name" in data[0]

--- a/tests/test_strategy_performance_endpoint.py
+++ b/tests/test_strategy_performance_endpoint.py
@@ -13,12 +13,12 @@ from solbot.bootstrap import BootstrapCoordinator
 from prometheus_client import REGISTRY
 
 
-def _clear_registry() -> None:
-    for collector in list(REGISTRY._collector_to_names.keys()):
-        try:
-            REGISTRY.unregister(collector)
-        except KeyError:
-            pass
+class DummyOracle(PriceOracle):
+    async def price(self, token: str) -> float:  # type: ignore[override]
+        return 25.0
+
+    async def volume(self, token: str) -> float:  # type: ignore[override]
+        return 0.0
 
 
 class DummyLM:
@@ -26,12 +26,12 @@ class DummyLM:
         return "full"
 
 
-class DummyOracle(PriceOracle):
-    async def price(self, token: str) -> float:  # type: ignore[override]
-        return 1.0
-
-    async def volume(self, token: str) -> float:  # type: ignore[override]
-        return 0.0
+def _clear_registry() -> None:
+    for collector in list(REGISTRY._collector_to_names.keys()):
+        try:
+            REGISTRY.unregister(collector)
+        except KeyError:
+            pass
 
 
 def build_app():
@@ -45,7 +45,6 @@ def build_app():
         db_path=tmp.name,
         bootstrap=False,
     )
-    lm = DummyLM()
     dal = DAL(cfg.db_path)
     oracle = DummyOracle()
     connector = PaperConnector(dal, oracle)
@@ -55,29 +54,19 @@ def build_app():
     posterior = PosteriorEngine(n_features=fe.dim)
     assets = AssetService(dal)
     bootstrap = BootstrapCoordinator()
+    lm = DummyLM()
     app = create_app(cfg, lm, risk, trade, assets, bootstrap, fe, posterior)
     api_module.oracle = connector.oracle
-    return app, risk
+    return app
 
 
-def test_risk_portfolio_endpoint():
-    app, risk = build_app()
-    risk.update_equity(100.0)
+def test_strategy_performance_periods():
+    app = build_app()
     with TestClient(app) as client:
-        resp = client.get("/risk/portfolio")
-        assert resp.status_code == 200
-        data = resp.json()
-        assert {"equity", "change", "change_pct", "max_drawdown", "leverage", "exposure", "position_size"} <= data.keys()
-
-
-def test_risk_portfolio_exposure_ratio():
-    app, risk = build_app()
-    risk.update_equity(100.0)
-    risk.add_position("SOL", qty=1.0, price=10.0)
-    risk.update_equity(100.0)
-    with TestClient(app) as client:
-        resp = client.get("/risk/portfolio")
-        assert resp.status_code == 200
-        data = resp.json()
-        expected = risk.total_exposure() / risk.equity
-        assert data["exposure"] == expected
+        r7 = client.get("/strategy/performance?period=7d")
+        r30 = client.get("/strategy/performance?period=30d")
+        assert r7.status_code == 200 and r30.status_code == 200
+        data7 = r7.json()
+        data30 = r30.json()
+        assert data7 != data30
+        assert all("name" in s and "pnl" in s for s in data7)

--- a/tests/test_strategy_performance_matrix.py
+++ b/tests/test_strategy_performance_matrix.py
@@ -1,0 +1,21 @@
+import pytest
+from sqlmodel import SQLModel
+from httpx import AsyncClient
+
+
+@pytest.fixture(scope="module")
+def test_app():
+    SQLModel.metadata.clear()
+    from src.solbot.server.api import app
+    return app
+
+
+@pytest.mark.asyncio
+async def test_performance_matrix_endpoint(test_app):
+    async with AsyncClient(app=test_app, base_url="http://test") as ac:
+        res = await ac.get("/strategy/performance_matrix?period=7d")
+    assert res.status_code == 200
+    data = res.json()
+    assert "days" in data and len(data["days"]) > 0
+    assert "strategies" in data and len(data["strategies"]) == 3
+    assert "risk" in data and "sharpe" in data["risk"]

--- a/tests/test_token_scanner.py
+++ b/tests/test_token_scanner.py
@@ -1,0 +1,66 @@
+import tempfile
+import asyncio
+from fastapi.testclient import TestClient
+from prometheus_client import REGISTRY
+
+from solbot.utils import BotConfig
+from solbot.engine import RiskManager, TradeEngine
+from solbot.bootstrap import BootstrapCoordinator
+from solbot.persistence import DAL
+from solbot.persistence.assets import AssetService
+from solbot.exchange import PaperConnector
+from solbot.oracle.coingecko import PriceOracle
+from solbot.server import create_app
+
+
+class DummyLM:
+    def license_mode(self, wallet: str) -> str:
+        return "full"
+
+
+def create_test_app() -> TestClient:
+    for collector in list(REGISTRY._collector_to_names.keys()):
+        REGISTRY.unregister(collector)
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    cfg = BotConfig(
+        rpc_ws="ws://localhost:8900",
+        rpc_http="http://localhost:8900",
+        log_level="INFO",
+        wallet="111",
+        db_path=tmp.name,
+        bootstrap=False,
+    )
+    lm = DummyLM()
+    dal = DAL(cfg.db_path)
+
+    class DummyOracle(PriceOracle):
+        async def price(self, token: str) -> float:  # type: ignore[override]
+            return 1.0
+
+        async def volume(self, token: str) -> float:  # type: ignore[override]
+            return 1_000.0
+
+    oracle = DummyOracle()
+    connector = PaperConnector(dal, oracle)
+    risk = RiskManager()
+    trade = TradeEngine(risk, connector, dal)
+    bootstrap = BootstrapCoordinator()
+
+    class DummyAssets(AssetService):
+        def refresh(self):
+            return self.list_assets()
+
+    assets = DummyAssets(dal)
+    assets.dal.save_assets([{"symbol": "SOL"}])
+    app = create_app(cfg, lm, risk, trade, assets, bootstrap)
+    return TestClient(app)
+
+
+def test_token_scanner_start_stop():
+    with create_test_app() as client:
+        resp = client.post("/engine/start")
+        assert resp.status_code == 200
+        assert client.app.state.scanner_task is not None
+        resp = client.post("/engine/stop")
+        assert resp.status_code == 200
+        assert client.app.state.scanner_task is None

--- a/web/public/dashboard.css
+++ b/web/public/dashboard.css
@@ -4,12 +4,49 @@
         
         body {
             font-family: 'Inter', sans-serif;
+        }
+
+        html.theme-seeker {
             background: radial-gradient(ellipse at center, #1a0a00 0%, #000000 70%);
+            color: #ffffff;
+        }
+
+        html.theme-dark {
+            background: #0a0a0a;
+            color: #ffffff;
+        }
+
+        html.theme-light {
+            background: #f5f5f5;
+            color: #000000;
+        }
+
+        html.theme-light .hologram-panel {
+            background: rgba(255, 255, 255, 0.9);
+            border: 1px solid rgba(0, 0, 0, 0.1);
+            color: #000000;
+        }
+
+        html.theme-light .hologram-panel::before {
+            background: none;
+        }
+
+        .atmospheric-glow {
+            position: fixed;
+            inset: 0;
+            background: radial-gradient(ellipse at center, rgba(255,140,0,0.05) 0%, rgba(0,0,0,0) 70%);
+            pointer-events: none;
+            animation: glowPulse 120s linear infinite;
+        }
+
+        .no-anim .atmospheric-glow, html:not(.theme-seeker) .atmospheric-glow {
+            display: none;
         }
 
         .dashboard-grid {
             display: grid;
-            grid-template-columns: repeat(3, 1fr);
+            grid-template-columns: 1fr;
+            gap: 2rem;
         }
 
         @media (max-width:1279px) {
@@ -56,6 +93,11 @@
         @keyframes borderFlow {
             0%, 100% { background-position: 0% 50%; }
             50% { background-position: 100% 50%; }
+        }
+
+        @keyframes glowPulse {
+            0%,100% { opacity: 0.4; }
+            50% { opacity: 0.7; }
         }
 
         @media (prefers-reduced-motion: reduce) {

--- a/web/public/dashboard.html
+++ b/web/public/dashboard.html
@@ -3,7 +3,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <!-- TODO[AGENTS-AUDIT §10]: Update branding to "SOL SEEKER" with space and modern font -->
     <title>SOL SEEKER Dashboard</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -65,14 +64,31 @@
     <script src="js/nav.js"></script>
     <script src="js/portfolio.js"></script>
     <script src="js/analytics.js"></script>
+    <script src="js/debug.js"></script>
+    <script src="js/walkthrough.js"></script>
 
         <link rel="stylesheet" href="dashboard.css">
 </head>
 <body class="text-white font-display min-h-screen relative">
+    <!-- Mode Modal -->
+    <div id="modeModal" class="fixed inset-0 bg-black/80 flex items-center justify-center z-50 hidden">
+        <div class="bg-panel-black p-6 rounded text-center space-y-4">
+            <p class="hologram-text">Select dashboard mode</p>
+            <div class="space-x-4">
+                <button id="modeBasic" class="px-4 py-2 bg-blade-amber/20 text-blade-amber rounded">Basic</button>
+                <button id="modeAdvanced" class="px-4 py-2 bg-blade-amber/20 text-blade-amber rounded">Advanced</button>
+            </div>
+        </div>
+    </div>
     <!-- Atmospheric Background -->
+    <div class="atmospheric-glow"></div>
     <div id="toastContainer" class="fixed top-4 right-4 space-y-2 z-50"></div>
     <div id="wsReconnectBanner" class="hidden fixed top-16 left-1/2 -translate-x-1/2 bg-blade-orange/80 text-white px-4 py-1 rounded text-xs z-50">Reconnecting…</div>
     <div id="licenseExpiryBanner" class="hidden fixed top-24 left-1/2 -translate-x-1/2 bg-blade-amber/80 text-black px-4 py-1 rounded text-xs z-50">LICENSE EXPIRES SOON</div>
+    <div id="walkthroughOverlay" class="hidden fixed inset-0 bg-black/70 z-50 flex flex-col items-center justify-center text-center p-4">
+        <div id="walkthroughText" class="mb-4"></div>
+        <button id="walkthroughNext" class="px-4 py-2 bg-blade-amber text-black rounded">Next</button>
+    </div>
 
     <!-- Fixed Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-glass-black border-b border-blade-amber/30 backdrop-filter backdrop-blur-lg">
@@ -81,7 +97,6 @@
             <div class="flex items-center space-x-8">
                 <button id="nav-toggle" class="text-2xl mr-4" aria-expanded="false" aria-controls="side-menu" aria-label="Open menu">☰</button>
                 <div class="flex items-center space-x-4">
-                    <!-- TODO[AGENTS-AUDIT §10]: Rename heading to "SOL SEEKER DASHBOARD" -->
                     <h1 class="text-3xl font-bold text-white hologram-text tracking-wider">
                         SOL SEEKER DASHBOARD
                     </h1>
@@ -149,20 +164,13 @@
             </h2>
             <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <!-- Total Portfolio Value -->
-                <!-- TODO[AGENTS-AUDIT §2]: Wire to /chart/portfolio and show 10 SOL demo start with USD conversion -->
                 <div class="metric-card p-6 rounded scan-lines">
                     <div class="flex items-center justify-between mb-2">
                         <span class="text-sm hologram-text text-blade-amber/80">PORTFOLIO VALUE</span>
-                          <!-- TODO[AGENTS-AUDIT §2]: Align sparkline left →
-                               right and overlay % change line with legend. -->
-                          <canvas id="portfolioSpark" class="w-12 h-6"></canvas>
+                          <canvas id="sparkline" class="w-12 h-6"></canvas>
                     </div>
-                    <div class="text-3xl font-bold amber-glow data-flicker" id="portfolioValue">
-                        10 SOL ($0.00)
-                    </div>
-                    <div class="text-sm hologram-text text-cyan-glow mt-1" id="portfolioChange">
-                        +0.00 SOL ($0.00) (+0.00%)
-                    </div>
+                    <div class="text-3xl font-bold amber-glow data-flicker" id="portfolioValue"></div>
+                    <div class="text-sm hologram-text text-cyan-glow mt-1" id="portfolioChange"></div>
                 </div>
 
                 <!-- Realized P&L -->
@@ -183,7 +191,6 @@
                 </div>
 
                 <!-- Open Positions -->
-                <!-- TODO[AGENTS-AUDIT §2]: Replace counts with horizontal mini-card map sourced from /positions/ws -->
                 <div class="metric-card p-6 rounded scan-lines overflow-x-auto">
                     <div class="flex items-center justify-between mb-2">
                         <span class="text-sm hologram-text text-blade-amber/80">OPEN POSITIONS</span>
@@ -297,7 +304,6 @@
                 </div>
 
                 <!-- Risk Metrics -->
-                <!-- TODO[AGENTS-AUDIT §5]: Wire to `/risk/portfolio` and replace static placeholders with live drawdown, position size, leverage, exposure -->
 <div class="hologram-panel p-6 rounded scan-lines" id="riskMetrics">
                     <h3 class="text-lg font-semibold text-white hologram-text mb-6 tracking-wider">
                         PORTFOLIO RISK
@@ -346,8 +352,6 @@
             <!-- Right Column: Charts and Feed -->
             <div class="xl:col-span-2 lg:col-span-1 space-y-8">
                 <!-- Chart Navigation Tabs -->
-                  <!-- TODO[AGENTS-AUDIT §4]: Active tab is unhighlighted; use
-                       `aria-selected` and Tailwind classes to toggle. -->
                   <div class="flex space-x-4 mb-6">
                       <button id="equityTab" aria-selected="true" class="chart-tab px-4 py-2 bg-blade-amber/20 text-blade-amber rounded text-sm hologram-text border border-blade-amber/50" data-chart="equity">
                           EQUITY CURVE
@@ -389,9 +393,6 @@
                 </div>
 
                   <!-- P&L Breakdown Chart -->
-                  <!-- TODO[AGENTS-AUDIT §4]: Replace static SVG with Chart.js
-                       bar chart from `/pnl/daily?days=14` and donut from
-                       `/strategy/breakdown` including Liquidity & Other segments. -->
                   <div class="chart-panel hologram-panel p-6 rounded scan-lines hidden" id="pnlChart" hidden>
                     <div class="flex justify-between items-center mb-6">
                         <h3 class="text-lg font-semibold text-white hologram-text tracking-wider">
@@ -419,9 +420,6 @@
                 </div>
 
                   <!-- Market Data Chart -->
-                  <!-- TODO[AGENTS-AUDIT §4]: Poll `/market/active` every 10 s for
-                       new/trending tokens; populate table with volume,
-                       volatility, liquidity, spread and link to TradingView. -->
                   <div class="chart-panel hologram-panel p-6 rounded scan-lines hidden" id="marketChart" hidden>
                     <div class="flex justify-between items-center mb-6">
                         <h3 class="text-lg font-semibold text-white hologram-text tracking-wider">
@@ -451,9 +449,6 @@
                 </div>
 
                   <!-- Regime Analysis Chart -->
-                  <!-- TODO[AGENTS-AUDIT §4]: Consume `/posterior` websocket to
-                       render regime probabilities and rug risk; hide if
-                       endpoint unavailable. -->
                   <div class="chart-panel hologram-panel p-6 rounded scan-lines hidden" id="regimeChart" hidden>
                     <div class="flex justify-between items-center mb-6">
                         <h3 class="text-lg font-semibold text-white hologram-text tracking-wider">
@@ -715,14 +710,12 @@
 
                       <!-- Risk Analytics -->
                         <div class="hologram-panel p-6 rounded scan-lines" id="riskAnalyticsPanel">
-                            <!-- TODO[AGENTS-AUDIT §5]: Populate risk analytics via /strategy/risk and tidy padding -->
                           <h3 class="text-lg font-semibold text-white hologram-text tracking-wider mb-6">RISK ANALYTICS</h3>
                           <div id="riskAnalytics" class="grid grid-cols-2 gap-4 text-xs"></div>
                       </div>
 
                       <!-- MEV Protection & Alpha Signals -->
-                      <div class="hologram-panel p-6 rounded scan-lines">
-                          <!-- TODO[AGENTS-AUDIT §5]: Wire MEV Shield & Alpha Signals to /mev/status and /alpha/signals -->
+                        <div class="hologram-panel p-6 rounded scan-lines advanced" id="mevAlphaPanel">
                         <div class="flex justify-between items-center mb-6">
                             <h3 class="text-lg font-semibold text-white hologram-text tracking-wider">
                                 MEV SHIELD & ALPHA SIGNALS
@@ -759,22 +752,22 @@
                                         </div>
                                     </div>
                                     <div class="text-right">
-                                        <div class="hologram-text text-cyan-glow font-bold">$2,847</div>
+                                        <div class="hologram-text text-cyan-glow font-bold" id="mevSaved">--</div>
                                         <div class="hologram-text text-xs text-blade-amber/60">SAVED TODAY</div>
                                     </div>
                                 </div>
                                 <div class="grid grid-cols-3 gap-3 text-xs">
                                     <div>
                                         <div class="hologram-text text-blade-amber/80">ATTACKS BLOCKED</div>
-                                        <div class="hologram-text text-cyan-glow font-bold">47</div>
+                                        <div class="hologram-text text-cyan-glow font-bold" id="mevBlocked">0</div>
                                     </div>
                                     <div>
                                         <div class="hologram-text text-blade-amber/80">SUCCESS RATE</div>
-                                        <div class="hologram-text text-cyan-glow font-bold">99.2%</div>
+                                        <div class="hologram-text text-cyan-glow font-bold" id="mevSuccess">0%</div>
                                     </div>
                                     <div>
                                         <div class="hologram-text text-blade-amber/80">LATENCY</div>
-                                        <div class="hologram-text text-cyan-glow font-bold">3ms</div>
+                                        <div class="hologram-text text-cyan-glow font-bold" id="mevLatency">0ms</div>
                                     </div>
                                 </div>
                             </div>
@@ -799,22 +792,22 @@
                                         </div>
                                     </div>
                                     <div class="text-right">
-                                        <div class="hologram-text text-blade-amber font-bold">STRONG</div>
+                                        <div class="hologram-text text-blade-amber font-bold" id="alphaStrength">--</div>
                                         <div class="hologram-text text-xs text-blade-amber/60">SIGNAL STRENGTH</div>
                                     </div>
                                 </div>
                                 <div class="space-y-2">
                                     <div class="flex justify-between text-xs">
                                         <span class="hologram-text text-blade-amber/80">SOCIAL SENTIMENT</span>
-                                        <span class="hologram-text text-cyan-glow">BULLISH (8.2/10)</span>
+                                        <span class="hologram-text text-cyan-glow" id="alphaSentiment">--</span>
                                     </div>
                                     <div class="flex justify-between text-xs">
                                         <span class="hologram-text text-blade-amber/80">ON-CHAIN MOMENTUM</span>
-                                        <span class="hologram-text text-cyan-glow">STRONG (7.8/10)</span>
+                                        <span class="hologram-text text-cyan-glow" id="alphaMomentum">--</span>
                                     </div>
                                     <div class="flex justify-between text-xs">
                                         <span class="hologram-text text-blade-amber/80">WHALE ACTIVITY</span>
-                                        <span class="hologram-text text-blade-yellow">MODERATE (6.1/10)</span>
+                                        <span class="hologram-text text-blade-yellow" id="alphaWhales">--</span>
                                     </div>
                                 </div>
                             </div>
@@ -848,7 +841,7 @@
                 </div>
 
                 <!-- Enhanced Trading Feed with Social Sentiment -->
-                <div class="grid grid-cols-1 xl:grid-cols-2 gap-6 mt-8">
+                <div class="grid grid-cols-1 xl:grid-cols-2 gap-6 mt-2">
                     <!-- Neural Trading Feed -->
                     <div class="hologram-panel p-6 rounded scan-lines">
                         <div class="flex justify-between items-center mb-6">
@@ -943,118 +936,45 @@
                 </div>
 
                 <!-- Performance Analytics & Backtesting -->
-                <div class="grid grid-cols-1 xl:grid-cols-2 gap-6 mt-8">
+                <div class="grid grid-cols-1 xl:grid-cols-2 gap-6 mt-2">
                     <!-- Strategy Performance Heatmap -->
                     <div class="hologram-panel p-6 rounded scan-lines">
-                        <div class="flex justify-between items-center mb-6">
+                        <div class="flex justify-between items-center mb-2">
                             <h3 class="text-lg font-semibold text-white hologram-text tracking-wider">
                                 STRATEGY PERFORMANCE MATRIX
-                                <!-- TODO[AGENTS-AUDIT §5]: Replace static sample data with /strategy/performance_matrix and tighten spacing -->
-                                <!-- TODO[AGENTS-AUDIT §5]: Replace static SOL totals with /strategy/performance_matrix data -->
                             </h3>
                             <div class="flex space-x-2">
-                                <button class="px-3 py-1 bg-blade-amber/20 text-blade-amber rounded text-xs hologram-text border border-blade-amber/50">7D</button>
-                                <button class="px-3 py-1 bg-void-black/50 text-blade-amber/60 rounded text-xs hologram-text border border-blade-amber/20">30D</button>
+                                <button id="perf7d" class="px-3 py-1 bg-blade-amber/20 text-blade-amber rounded text-xs hologram-text border border-blade-amber/50">7D</button>
+                                <button id="perf30d" class="px-3 py-1 bg-void-black/50 text-blade-amber/60 rounded text-xs hologram-text border border-blade-amber/20">30D</button>
                             </div>
                         </div>
-                        
+
                         <div class="space-y-4">
                             <!-- Performance Heatmap -->
-                            <div class="grid grid-cols-7 gap-1">
-                                <!-- Days of week header -->
-                                <div class="text-xs hologram-text text-blade-amber/60 text-center">M</div>
-                                <div class="text-xs hologram-text text-blade-amber/60 text-center">T</div>
-                                <div class="text-xs hologram-text text-blade-amber/60 text-center">W</div>
-                                <div class="text-xs hologram-text text-blade-amber/60 text-center">T</div>
-                                <div class="text-xs hologram-text text-blade-amber/60 text-center">F</div>
-                                <div class="text-xs hologram-text text-blade-amber/60 text-center">S</div>
-                                <div class="text-xs hologram-text text-blade-amber/60 text-center">S</div>
-                                
-                                <!-- Week 1 -->
-                                <div class="w-8 h-8 bg-cyan-glow/80 rounded tooltip-trigger relative">
-                                    <div class="tooltip absolute bottom-full mb-2 px-2 py-1 text-xs rounded">+2.4 SOL</div>
-                                </div>
-                                <div class="w-8 h-8 bg-cyan-glow/60 rounded tooltip-trigger relative">
-                                    <div class="tooltip absolute bottom-full mb-2 px-2 py-1 text-xs rounded">+1.8 SOL</div>
-                                </div>
-                                <div class="w-8 h-8 bg-blade-orange/40 rounded tooltip-trigger relative">
-                                    <div class="tooltip absolute bottom-full mb-2 px-2 py-1 text-xs rounded">-0.3 SOL</div>
-                                </div>
-                                <div class="w-8 h-8 bg-cyan-glow/90 rounded tooltip-trigger relative">
-                                    <div class="tooltip absolute bottom-full mb-2 px-2 py-1 text-xs rounded">+3.1 SOL</div>
-                                </div>
-                                <div class="w-8 h-8 bg-cyan-glow/70 rounded tooltip-trigger relative">
-                                    <div class="tooltip absolute bottom-full mb-2 px-2 py-1 text-xs rounded">+2.0 SOL</div>
-                                </div>
-                                <div class="w-8 h-8 bg-blade-amber/50 rounded tooltip-trigger relative">
-                                    <div class="tooltip absolute bottom-full mb-2 px-2 py-1 text-xs rounded">+0.8 SOL</div>
-                                </div>
-                                <div class="w-8 h-8 bg-blade-orange/60 rounded tooltip-trigger relative">
-                                    <div class="tooltip absolute bottom-full mb-2 px-2 py-1 text-xs rounded">-0.5 SOL</div>
-                                </div>
-                                
-                                <!-- Week 2 -->
-                                <div class="w-8 h-8 bg-cyan-glow/50 rounded tooltip-trigger relative">
-                                    <div class="tooltip absolute bottom-full mb-2 px-2 py-1 text-xs rounded">+1.2 SOL</div>
-                                </div>
-                                <div class="w-8 h-8 bg-cyan-glow/80 rounded tooltip-trigger relative">
-                                    <div class="tooltip absolute bottom-full mb-2 px-2 py-1 text-xs rounded">+2.7 SOL</div>
-                                </div>
-                                <div class="w-8 h-8 bg-cyan-glow/60 rounded tooltip-trigger relative">
-                                    <div class="tooltip absolute bottom-full mb-2 px-2 py-1 text-xs rounded">+1.9 SOL</div>
-                                </div>
-                                <div class="w-8 h-8 bg-blade-amber/40 rounded tooltip-trigger relative">
-                                    <div class="tooltip absolute bottom-full mb-2 px-2 py-1 text-xs rounded">+0.4 SOL</div>
-                                </div>
-                                <div class="w-8 h-8 bg-cyan-glow/100 rounded tooltip-trigger relative">
-                                    <div class="tooltip absolute bottom-full mb-2 px-2 py-1 text-xs rounded">+4.2 SOL</div>
-                                </div>
-                                <div class="w-8 h-8 bg-cyan-glow/70 rounded tooltip-trigger relative">
-                                    <div class="tooltip absolute bottom-full mb-2 px-2 py-1 text-xs rounded">+2.1 SOL</div>
-                                </div>
-                                <div class="w-8 h-8 bg-blade-amber/30 rounded tooltip-trigger relative">
-                                    <div class="tooltip absolute bottom-full mb-2 px-2 py-1 text-xs rounded">+0.2 SOL</div>
-                                </div>
-                            </div>
-                            
+                            <div id="perfMatrixGrid" class="grid grid-cols-7 gap-1"></div>
+
                             <!-- Strategy Breakdown -->
-                            <div class="grid grid-cols-3 gap-4">
-                                <div class="bg-void-black/50 p-3 rounded border border-blade-cyan/30">
-                                    <div class="hologram-text text-cyan-glow font-bold text-sm">SNIPER</div>
-                                    <div class="hologram-text text-white text-lg">+12.4 SOL</div>
-                                    <div class="hologram-text text-cyan-glow text-xs">94% Win Rate</div>
-                                </div>
-                                <div class="bg-void-black/50 p-3 rounded border border-blade-amber/30">
-                                    <div class="hologram-text text-blade-amber font-bold text-sm">ARBITRAGE</div>
-                                    <div class="hologram-text text-white text-lg">+8.7 SOL</div>
-                                    <div class="hologram-text text-blade-amber text-xs">87% Win Rate</div>
-                                </div>
-                                <div class="bg-void-black/50 p-3 rounded border border-blade-yellow/30">
-                                    <div class="hologram-text text-blade-yellow font-bold text-sm">MARKET MAKING</div>
-                                    <div class="hologram-text text-white text-lg">+3.2 SOL</div>
-                                    <div class="hologram-text text-blade-yellow text-xs">76% Win Rate</div>
-                                </div>
-                            </div>
-                            
+                            <div id="perfStrategyBreakdown" class="grid grid-cols-3 gap-4"></div>
+
                             <!-- Risk Metrics -->
                             <div class="bg-void-black/50 p-4 rounded border border-blade-orange/30">
                                 <div class="hologram-text text-blade-orange font-bold mb-3">RISK ANALYTICS</div>
                                 <div class="grid grid-cols-2 gap-4 text-xs">
                                     <div>
                                         <div class="hologram-text text-blade-amber/80">SHARPE RATIO</div>
-                                        <div class="hologram-text text-cyan-glow font-bold">2.84</div>
+                                        <div id="perfSharpe" class="hologram-text text-cyan-glow font-bold">--</div>
                                     </div>
                                     <div>
                                         <div class="hologram-text text-blade-amber/80">MAX DRAWDOWN</div>
-                                        <div class="hologram-text text-blade-orange font-bold">-5.2%</div>
+                                        <div id="perfDrawdown" class="hologram-text text-blade-orange font-bold">--</div>
                                     </div>
                                     <div>
                                         <div class="hologram-text text-blade-amber/80">VOLATILITY</div>
-                                        <div class="hologram-text text-white font-bold">12.4%</div>
+                                        <div id="perfVol" class="hologram-text text-white font-bold">--</div>
                                     </div>
                                     <div>
                                         <div class="hologram-text text-blade-amber/80">CALMAR RATIO</div>
-                                        <div class="hologram-text text-cyan-glow font-bold">4.67</div>
+                                        <div id="perfCalmar" class="hologram-text text-cyan-glow font-bold">--</div>
                                     </div>
                                 </div>
                             </div>
@@ -1062,116 +982,34 @@
                     </div>
 
                     <!-- AI Backtesting Lab -->
-                    <!-- TODO[AGENTS-AUDIT §6]: Implement date pickers, numeric allocations, and tie into trading parameters -->
                     <div class="hologram-panel p-6 rounded scan-lines">
-                        <div class="flex justify-between items-center mb-6">
-                            <h3 class="text-lg font-semibold text-white hologram-text tracking-wider">
-                                AI BACKTESTING LAB
-                            </h3>
-                            <button class="px-3 py-1 bg-blade-cyan/20 text-cyan-glow rounded text-xs hologram-text border border-blade-cyan/50">
-                                RUN TEST
-                            </button>
+                        <div class="flex justify-between items-center mb-4">
+                            <h3 class="text-lg font-semibold text-white hologram-text tracking-wider">AI BACKTESTING LAB</h3>
+                            <button id="runLab" class="px-3 py-1 bg-blade-cyan/20 text-cyan-glow rounded text-xs hologram-text border border-blade-cyan/50">RUN TEST</button>
                         </div>
-                        
                         <div class="space-y-4">
-                            <!-- Backtest Configuration -->
                             <div class="bg-void-black/50 p-4 rounded border border-blade-amber/30">
                                 <div class="hologram-text text-blade-amber font-bold mb-3">TEST PARAMETERS</div>
-                                <div class="space-y-3">
-                                    <div>
-                                        <label class="hologram-text text-blade-amber/80 text-xs block mb-1">TIME PERIOD</label>
-                                        <select class="w-full bg-void-black border border-blade-amber/30 rounded px-2 py-1 hologram-text text-white text-xs">
-                                            <option>Last 30 Days</option>
-                                            <option>Last 90 Days</option>
-                                            <option>Last 6 Months</option>
-                                            <option>Custom Range</option>
-                                        </select>
-                                    </div>
-                                    <div>
-                                        <label class="hologram-text text-blade-amber/80 text-xs block mb-1">INITIAL CAPITAL</label>
-                                        <input type="number" value="100" class="w-full bg-void-black border border-blade-amber/30 rounded px-2 py-1 hologram-text text-white text-xs" placeholder="SOL">
-                                    </div>
-                                    <div>
-                                        <label class="hologram-text text-blade-amber/80 text-xs block mb-1">STRATEGY MIX</label>
-                                        <div class="grid grid-cols-3 gap-2 text-xs">
-                                            <div>
-                                                <div class="hologram-text text-blade-amber/80">SNIPER</div>
-                                                <input type="range" min="0" max="100" value="50" class="w-full h-1 bg-void-black rounded-lg appearance-none cursor-pointer slider">
-                                            </div>
-                                            <div>
-                                                <div class="hologram-text text-blade-amber/80">ARB</div>
-                                                <input type="range" min="0" max="100" value="30" class="w-full h-1 bg-void-black rounded-lg appearance-none cursor-pointer slider">
-                                            </div>
-                                            <div>
-                                                <div class="hologram-text text-blade-amber/80">MM</div>
-                                                <input type="range" min="0" max="100" value="20" class="w-full h-1 bg-void-black rounded-lg appearance-none cursor-pointer slider">
-                                            </div>
-                                        </div>
-                                    </div>
+                                <div class="grid md:grid-cols-2 gap-3 text-xs">
+                                    <div><label class="hologram-text text-blade-amber/80 block mb-1">START</label><input type="date" id="labStart" class="w-full bg-void-black border border-blade-amber/30 rounded px-2 py-1 hologram-text text-white" /></div>
+                                    <div><label class="hologram-text text-blade-amber/80 block mb-1">END</label><input type="date" id="labEnd" class="w-full bg-void-black border border-blade-amber/30 rounded px-2 py-1 hologram-text text-white" /></div>
+                                    <div><label class="hologram-text text-blade-amber/80 block mb-1">SNIPER %</label><input type="number" id="labSniper" min="0" max="100" value="50" class="w-full bg-void-black border border-blade-amber/30 rounded px-2 py-1 hologram-text text-white" /></div>
+                                    <div><label class="hologram-text text-blade-amber/80 block mb-1">ARB %</label><input type="number" id="labArb" min="0" max="100" value="30" class="w-full bg-void-black border border-blade-amber/30 rounded px-2 py-1 hologram-text text-white" /></div>
+                                    <div><label class="hologram-text text-blade-amber/80 block mb-1">MM %</label><input type="number" id="labMM" min="0" max="100" value="20" class="w-full bg-void-black border border-blade-amber/30 rounded px-2 py-1 hologram-text text-white" /></div>
                                 </div>
                             </div>
-                            
-                            <!-- Backtest Results -->
                             <div class="bg-void-black/50 p-4 rounded border border-blade-cyan/30">
                                 <div class="hologram-text text-cyan-glow font-bold mb-3">SIMULATION RESULTS</div>
                                 <div class="space-y-2">
-                                    <div class="flex justify-between items-center">
-                                        <span class="hologram-text text-blade-amber/80 text-xs">FINAL BALANCE</span>
-                                        <span class="hologram-text text-cyan-glow font-bold">247.3 SOL</span>
-                                    </div>
-                                    <div class="flex justify-between items-center">
-                                        <span class="hologram-text text-blade-amber/80 text-xs">TOTAL RETURN</span>
-                                        <span class="hologram-text text-cyan-glow font-bold">+147.3%</span>
-                                    </div>
-                                    <div class="flex justify-between items-center">
-                                        <span class="hologram-text text-blade-amber/80 text-xs">TOTAL TRADES</span>
-                                        <span class="hologram-text text-white font-bold">1,247</span>
-                                    </div>
-                                    <div class="flex justify-between items-center">
-                                        <span class="hologram-text text-blade-amber/80 text-xs">WIN RATE</span>
-                                        <span class="hologram-text text-cyan-glow font-bold">89.2%</span>
-                                    </div>
-                                    <div class="flex justify-between items-center">
-                                        <span class="hologram-text text-blade-amber/80 text-xs">AVG TRADE</span>
-                                        <span class="hologram-text text-white font-bold">+0.12 SOL</span>
-                                    </div>
-                                </div>
-                            </div>
-                            
-                            <!-- Monte Carlo Analysis -->
-                            <div class="bg-void-black/50 p-4 rounded border border-blade-yellow/30">
-                                <div class="hologram-text text-blade-yellow font-bold mb-3">MONTE CARLO ANALYSIS</div>
-                                <div class="space-y-2 text-xs">
-                                    <div class="flex justify-between items-center">
-                                        <span class="hologram-text text-blade-amber/80">BEST CASE (95%)</span>
-                                        <span class="hologram-text text-cyan-glow font-bold">+284.7 SOL</span>
-                                    </div>
-                                    <div class="flex justify-between items-center">
-                                        <span class="hologram-text text-blade-amber/80">EXPECTED (50%)</span>
-                                        <span class="hologram-text text-white font-bold">+147.3 SOL</span>
-                                    </div>
-                                    <div class="flex justify-between items-center">
-                                        <span class="hologram-text text-blade-amber/80">WORST CASE (5%)</span>
-                                        <span class="hologram-text text-blade-orange font-bold">+89.1 SOL</span>
-                                    </div>
-                                    <div class="flex justify-between items-center">
-                                        <span class="hologram-text text-blade-amber/80">PROBABILITY OF PROFIT</span>
-                                        <span class="hologram-text text-cyan-glow font-bold">97.8%</span>
-                                    </div>
-                                </div>
-                            </div>
-                            
-                            <!-- Strategy Optimization -->
-                            <div class="bg-void-black/50 p-4 rounded border border-blade-orange/30">
-                                <div class="hologram-text text-blade-orange font-bold mb-3">AI OPTIMIZATION</div>
-                                <div class="space-y-2 text-xs">
-                                    <div class="hologram-text text-white">🎯 Increase Sniper allocation to 65% for +12% returns</div>
-                                    <div class="hologram-text text-white">⚡ Reduce position size during high volatility periods</div>
-                                    <div class="hologram-text text-white">🛡️ Add stop-loss at -15% for better risk management</div>
-                                    <div class="hologram-text text-white">📊 Consider DCA strategy during market downturns</div>
+                                    <div class="flex justify-between"><span class="hologram-text text-blade-amber/80">FINAL BALANCE</span><span id="labFinal" class="hologram-text text-cyan-glow font-bold">--</span></div>
+                                    <div class="flex justify-between"><span class="hologram-text text-blade-amber/80">TOTAL RETURN</span><span id="labReturn" class="hologram-text text-cyan-glow font-bold">--</span></div>
+                                    <div class="flex justify-between"><span class="hologram-text text-blade-amber/80">TOTAL TRADES</span><span id="labTrades" class="hologram-text text-white font-bold">--</span></div>
+                                    <div class="flex justify-between"><span class="hologram-text text-blade-amber/80">WIN RATE</span><span id="labWin" class="hologram-text text-cyan-glow font-bold">--</span></div>
+                                    <div class="flex justify-between"><span class="hologram-text text-blade-amber/80">AVG TRADE</span><span id="labAvg" class="hologram-text text-white font-bold">--</span></div>
                                 </div>
                             </div>
                         </div>
+                    </div>
                     </div>
                 </div>
             </div>
@@ -1361,12 +1199,6 @@
                         </div>
                     </div>
                 </div>
-                <!-- Supported Assets -->
-                <!-- TODO[AGENTS-AUDIT §7]: Remove supported assets panel; assets handled via demo asset selector -->
-<div class="bg-void-black/50 p-4 rounded border border-blade-amber/30 mb-4" id="assetPanel">
-                    <h4 class="hologram-text text-blade-amber font-bold mb-3">SUPPORTED ASSETS</h4>
-                    <select id="assetSelect" class="w-full bg-void-black border border-blade-amber/30 rounded px-3 py-2 hologram-text text-white text-sm"></select>
-                </div>
                 <!-- API Connection -->
                 <div class="bg-void-black/50 p-4 rounded border border-blade-amber/30 mb-4">
                     <h4 class="hologram-text text-blade-amber font-bold mb-3">API CONNECTION</h4>
@@ -1551,40 +1383,23 @@
                     </div>
                 </div>
             </div>
-            <!-- Feature Schema -->
-            <div class="bg-void-black/50 p-4 rounded border border-blade-cyan/30 mb-4" id="featureSchemaPanel">
-                <h4 class="hologram-text text-white font-bold mb-3">AI FEATURE SCHEMA</h4>
-                <div id="featureSchema" class="max-h-40 overflow-y-auto text-xs hologram-text text-white space-y-1"></div>
-            </div>
-
-            <!-- Feature Snapshot -->
-            <div class="bg-void-black/50 p-4 rounded border border-blade-cyan/30 mb-4" id="featureSnapshotPanel">
-                <h4 class="hologram-text text-white font-bold mb-3">CURRENT FEATURE SNAPSHOT</h4>
-                <div id="featureSnapshot" class="max-h-40 overflow-y-auto text-xs hologram-text text-white space-y-1"></div>
-            </div>
-
-            <!-- AI Feature Monitor -->
-            <div class="hologram-panel p-6 rounded scan-lines mt-8" id="featureStreamPanel">
-                <h3 class="text-lg font-semibold text-white hologram-text tracking-wider mb-4">
-                    AI FEATURE MONITOR
-                </h3>
-                <div id="featureStream" class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs hologram-text text-white"></div>
-            </div>
+            <!-- AI Diagnostics -->
+            <details class="hologram-panel p-6 rounded scan-lines mt-8 advanced" id="featurePanel">
+                <summary class="text-lg font-semibold text-white hologram-text tracking-wider cursor-pointer">AI DIAGNOSTICS</summary>
+                <div id="featureDiagnostics" class="grid grid-cols-2 md:grid-cols-4 gap-2 mt-4 text-xs hologram-text text-white"></div>
+            </details>
 
             <!-- Debug Console Section -->
-            <div class="mb-8">
+            <div class="mb-8 advanced">
                 <div class="flex justify-between items-center mb-4">
                     <h3 class="text-lg font-semibold text-white hologram-text tracking-wider">
                         DEBUG CONSOLE
                     </h3>
                     <div class="flex space-x-2">
-                        <select class="px-2 py-1 bg-blade-amber/20 text-blade-amber rounded text-xs hologram-text border border-blade-amber/50" id="logFilter">
-                            <option>ALL</option>
-                            <option>INFO</option>
-                            <option>DEBUG</option>
-                            <option>WARN</option>
-                            <option>ERROR</option>
-                        </select>
+                        <button class="px-2 py-1 bg-void-black/50 text-blade-amber/60 rounded text-xs hologram-text border border-blade-amber/20" id="generateLogs">GENERATE</button>
+                        <button class="px-2 py-1 bg-void-black/50 text-blade-amber/60 rounded text-xs hologram-text border border-blade-amber/20 log-filter" data-level="ERROR">ERRORS</button>
+                        <button class="px-2 py-1 bg-void-black/50 text-blade-amber/60 rounded text-xs hologram-text border border-blade-amber/20 log-filter" data-level="INFO">INFO</button>
+                        <button class="px-2 py-1 bg-void-black/50 text-blade-amber/60 rounded text-xs hologram-text border border-blade-amber/20 log-filter" data-level="ALL">ALL</button>
                         <button class="px-2 py-1 bg-void-black/50 text-blade-amber/60 rounded text-xs hologram-text border border-blade-amber/20" id="clearLogs">CLEAR</button>
 
                         <button class="px-2 py-1 bg-void-black/50 text-blade-amber/60 rounded text-xs hologram-text border border-blade-amber/20" id="apiExplorerBtn">API MAP</button>
@@ -2090,6 +1905,30 @@
                 updateLicenseMode(dashboardState.isDemo);
             }
         }
+
+        // Basic vs advanced display
+        function applyDashboardMode(mode) {
+            localStorage.setItem('dashboard_mode', mode);
+            document.querySelectorAll('.advanced').forEach(el => {
+                el.classList.toggle('hidden', mode === 'basic');
+            });
+        }
+
+        const savedMode = localStorage.getItem('dashboard_mode');
+        if (!savedMode) {
+            document.getElementById('modeModal').classList.remove('hidden');
+        } else {
+            applyDashboardMode(savedMode);
+        }
+
+        document.getElementById('modeBasic').addEventListener('click', () => {
+            applyDashboardMode('basic');
+            document.getElementById('modeModal').classList.add('hidden');
+        });
+        document.getElementById('modeAdvanced').addEventListener('click', () => {
+            applyDashboardMode('advanced');
+            document.getElementById('modeModal').classList.add('hidden');
+        });
         async function saveMode() {
             const mode = modeSelect.value;
             demoOptions.classList.toggle('hidden', mode !== 'demo');
@@ -2130,10 +1969,6 @@
             });
         });
 
-        // Debug console functionality
-        const debugConsole = document.getElementById('debugConsole');
-        const logFilter = document.getElementById('logFilter');
-        const clearLogs = document.getElementById('clearLogs');
         const apiExplorerBtn = document.getElementById('apiExplorerBtn');
         const apiExplorerModal = document.getElementById('apiExplorerModal');
         const apiExplorerContent = document.getElementById('apiExplorerContent');
@@ -2142,43 +1977,6 @@
         const aboutModal = document.getElementById('aboutModal');
         const aboutContent = document.getElementById('aboutContent');
         const closeAboutModal = document.getElementById('closeAboutModal');
-        const logBuffer = [];
-        const MAX_LOGS = 500;
-
-        function levelClass(level) {
-            switch (level) {
-                case 'DEBUG': return 'text-blade-amber';
-                case 'WARN': return 'text-blade-orange';
-                case 'ERROR': return 'text-red-500';
-                case 'INFO': return 'text-white';
-                default: return 'text-white';
-            }
-        }
-
-        function renderLogs() {
-            debugConsole.innerHTML = '';
-            const level = logFilter.value;
-            for (const log of logBuffer) {
-                if (level !== 'ALL' && log.level !== level) continue;
-                const div = document.createElement('div');
-                div.className = levelClass(log.level);
-                div.textContent = `[${new Date(log.timestamp).toLocaleTimeString()}] ${log.level}: ${log.message}`;
-                debugConsole.appendChild(div);
-            }
-            debugConsole.scrollTop = debugConsole.scrollHeight;
-        }
-
-        function appendLog(entry) {
-            logBuffer.push(entry);
-            if (logBuffer.length > MAX_LOGS) logBuffer.shift();
-            renderLogs();
-        }
-
-        logFilter.addEventListener('change', renderLogs);
-        clearLogs.addEventListener('click', () => {
-            logBuffer.length = 0;
-            renderLogs();
-        });
 
         apiExplorerBtn?.addEventListener('click', async () => {
             try {
@@ -2346,7 +2144,6 @@
                 this.disabled = false;
             }
         });
-        let backtestEndpoint = null;
 
         async function runBacktest() {
             // TODO[AGENTS-AUDIT §6]: support custom date pickers and integrate trading parameters
@@ -2383,38 +2180,32 @@
             try {
                 const res = await apiClient.runBacktest(params);
                 if (!res || !res.id) throw new Error('start failed');
-                backtestEndpoint = `/backtest/ws/${res.id}`;
-                wsClient.connect(backtestEndpoint, (msg) => {
-                    if (msg.progress !== undefined) {
-                        bar.style.width = `${msg.progress}%`;
-                    }
-                    if (msg.cancelled) {
-                        wsClient.disconnect(backtestEndpoint);
-                        backtestEndpoint = null;
-                        btn.disabled = false;
-                        btn.textContent = 'RUN BACKTEST';
-                        cancelBtn.classList.add('hidden');
-                        progress.classList.add('hidden');
-                        bar.style.width = '0';
-                        return;
-                    }
-                    if (msg.pnl !== undefined) {
-                        document.getElementById('backtestPnL').textContent = formatSol(msg.pnl, solPrice);
-                        document.getElementById('backtestStats').textContent = `DD ${(msg.drawdown * 100).toFixed(2)}% • SHARPE ${msg.sharpe.toFixed(2)}`;
-                        wsClient.disconnect(backtestEndpoint);
-                        backtestEndpoint = null;
-                        btn.disabled = false;
-                        btn.textContent = 'RUN BACKTEST';
-                        cancelBtn.classList.add('hidden');
-                        progress.classList.add('hidden');
-                        bar.style.width = '0';
-                    }
-                });
-                cancelBtn.onclick = () => {
-                    if (backtestEndpoint) {
-                        wsClient.send(backtestEndpoint, { action: 'cancel' });
+                const ws = new WebSocket(apiClient.getWebSocketURL(`/backtest/ws/${res.id}`));
+                ws.onmessage = (ev) => {
+                    try {
+                        const msg = JSON.parse(ev.data);
+                        if (msg.progress !== undefined) {
+                            bar.style.width = `${msg.progress}%`;
+                        }
+                        if (msg.cancelled) {
+                            ws.close();
+                        }
+                        if (msg.pnl !== undefined) {
+                            document.getElementById('backtestPnL').textContent = formatSol(msg.pnl, solPrice);
+                            document.getElementById('backtestStats').textContent = `DD ${(msg.drawdown * 100).toFixed(2)}% • SHARPE ${msg.sharpe.toFixed(2)}`;
+                        }
+                    } catch (e) {
+                        console.error('backtest ws parse failed', e);
                     }
                 };
+                ws.onclose = () => {
+                    btn.disabled = false;
+                    btn.textContent = 'RUN BACKTEST';
+                    cancelBtn.classList.add('hidden');
+                    progress.classList.add('hidden');
+                    bar.style.width = '0';
+                };
+                cancelBtn.onclick = () => ws.send(JSON.stringify({ action: 'cancel' }));
             } catch (err) {
                 console.error('Backtest failed:', err);
                 showToast('Backtest failed');
@@ -2847,16 +2638,6 @@
                 }
                 tradingActive = !!state?.running;
 
-                let assets = null;
-                if (!dashboardState.assets) {
-                    assets = await apiClient.getAssets().catch(() => null);
-                    if (assets) dashboardState.assets = assets;
-                }
-                let featureSchema = null;
-                if (!dashboardState.featureSchema) {
-                    featureSchema = await apiClient.getFeaturesSchema().catch(() => null);
-                    if (featureSchema) dashboardState.featureSchema = featureSchema;
-                }
                 const featureTs = featureSnap?.timestamp;
 
                 if (!dashboardState.licenseChecked || Date.now() - dashboardState.licenseChecked > 86400000) {
@@ -2874,10 +2655,8 @@
                 const render = () => {
                     if (assets) populateAssetSelect(assets);
                     updateModePanel();
-                    if (featureSchema) renderFeatureSchema(featureSchema);
                     if (Array.isArray(dashboardState.features)) {
-                        updateFeatureStream(dashboardState.features);
-                        renderFeatureSnapshot(dashboardState.features, featureTs);
+                        updateFeatureDiagnostics(dashboardState.features);
                     }
                     updatePortfolioMetrics();
                     updateRiskMetrics();
@@ -3005,16 +2784,8 @@
             }
             if (!map) return;
             dashboardState.positions = map;
-
             const entries = Object.entries(map);
             const qty = (p) => p.quantity ?? p.qty ?? 0;
-            const activePositions = entries.filter(([, p]) => qty(p) !== 0).length;
-            const longPositions = entries.filter(([, p]) => qty(p) > 0).length;
-            const shortPositions = entries.filter(([, p]) => qty(p) < 0).length;
-
-            document.getElementById('openPositionsTotal').textContent = activePositions.toString();
-            document.getElementById('openPositionsActive').textContent = `${activePositions} ACTIVE`;
-            document.getElementById('openPositionsBreakdown').textContent = `${longPositions} LONG • ${shortPositions} SHORT`;
 
             const list = document.getElementById('positionsList');
             if (list) {
@@ -3043,11 +2814,11 @@
                                 <div class="token-icon">${token[0] || '?'}</div>
                                 <div>
                                     <div class="hologram-text text-white font-bold">$${token}</div>
-                                    <div class="hologram-text text-xs text-blade-amber/60">${q}</div>
+                                    <div class="hologram-text text-xs text-blade-amber/60">${formatSol(q, solPrice)}</div>
                                 </div>
                             </div>
                             <div class="text-right">
-                                <div class="hologram-text ${color} font-bold">${pnl >= 0 ? '+' : ''}${pnl}</div>
+                                <div class="hologram-text ${color} font-bold">${formatSolChange(pnl, solPrice)}</div>
                             </div>
                         </div>`;
                     fragment.appendChild(row);
@@ -3231,19 +3002,6 @@
             }
         }
 
-        function populateAssetSelect(assets) {
-            if (!Array.isArray(assets)) return;
-            const sel = document.getElementById('assetSelect');
-            if (!sel) return;
-            sel.innerHTML = '';
-            assets.forEach(tok => {
-                const opt = document.createElement('option');
-                opt.value = tok;
-                opt.textContent = tok;
-                sel.appendChild(opt);
-            });
-        }
-
         function populateDemoAssets(assets) {
             const sel = document.getElementById('demoAssets');
             if (!sel || !Array.isArray(assets)) return;
@@ -3295,39 +3053,49 @@
             }
         }
 
-        function renderFeatureSchema(schema) {
-            const container = document.getElementById('featureSchema');
-            if (!container || !schema || !Array.isArray(schema.features)) return;
-            container.innerHTML = '';
-            const frag = document.createDocumentFragment();
-            schema.features.forEach(f => {
-                const row = document.createElement('div');
-                row.className = 'flex justify-between';
-                row.innerHTML = `<span>${f.index}: ${f.name}</span><span class="text-blade-amber/60">${f.category || ''}</span>`;
-                frag.appendChild(row);
-            });
-            container.appendChild(frag);
-        }
-
-        function renderFeatureSnapshot(features, timestamp) {
-            const container = document.getElementById('featureSnapshot');
+        const featureHistory = {};
+        function updateFeatureDiagnostics(features) {
+            const container = document.getElementById('featureDiagnostics');
             if (!container || !Array.isArray(features)) return;
-            container.innerHTML = '';
-            const frag = document.createDocumentFragment();
-            const schema = dashboardState.featureSchema?.features || [];
-            features.forEach((val, i) => {
-                const name = schema[i]?.name || `Feature ${i}`;
-                const row = document.createElement('div');
-                row.className = 'flex justify-between';
-                row.innerHTML = `<span>${name}</span><span class="text-blade-amber/60">${val}</span>`;
-                frag.appendChild(row);
+            features.forEach((val, idx) => {
+                const arr = featureHistory[idx] || (featureHistory[idx] = []);
+                arr.push(Number(val));
+                if (arr.length > 20) arr.shift();
             });
-            container.appendChild(frag);
-            const tsDiv = document.createElement('div');
-            tsDiv.className = 'text-blade-amber/60 mt-2';
-            const ts = timestamp ? new Date(timestamp * 1000) : new Date();
-            tsDiv.textContent = `Snapshot at ${ts.toLocaleTimeString()}`;
-            container.appendChild(tsDiv);
+            const entries = Object.entries(featureHistory).map(([idx, arr]) => {
+                const mean = arr.reduce((a, b) => a + b, 0) / arr.length;
+                const variance = arr.reduce((a, b) => a + (b - mean) ** 2, 0) / arr.length;
+                return { idx: Number(idx), variance, history: arr.slice() };
+            }).sort((a, b) => b.variance - a.variance).slice(0, 8);
+            container.innerHTML = '';
+            entries.forEach(f => {
+                const canvas = document.createElement('canvas');
+                canvas.width = 60; canvas.height = 20;
+                const ctx = canvas.getContext('2d');
+                const hist = f.history;
+                const min = Math.min(...hist);
+                const max = Math.max(...hist);
+                ctx.strokeStyle = '#00e5ff';
+                ctx.beginPath();
+                hist.forEach((v, i) => {
+                    const x = i / (hist.length - 1) * 60;
+                    const y = 20 - ((v - min) / (max - min || 1)) * 20;
+                    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+                });
+                ctx.stroke();
+                const wrap = document.createElement('div');
+                wrap.className = 'flex flex-col items-center';
+                wrap.appendChild(canvas);
+                const label = document.createElement('div');
+                label.className = 'hologram-text text-blade-amber/80';
+                label.textContent = f.idx;
+                wrap.appendChild(label);
+                const varDiv = document.createElement('div');
+                varDiv.className = 'hologram-text text-xs';
+                varDiv.textContent = f.variance.toFixed(4);
+                wrap.appendChild(varDiv);
+                container.appendChild(wrap);
+            });
         }
 
           function updateCatalystList(list) {
@@ -3384,18 +3152,6 @@
               parts.push(`${minutes}M`);
               return parts.join(' ');
           }
-
-        function updateFeatureStream(features) {
-            const container = document.getElementById('featureStream');
-            if (!container || !Array.isArray(features)) return;
-            container.innerHTML = '';
-            features.slice(0, 16).forEach((val, idx) => {
-                const div = document.createElement('div');
-                div.className = 'flex justify-between';
-                div.innerHTML = `<span>${idx}</span><span>${Number(val).toFixed(4)}</span>`;
-                container.appendChild(div);
-            });
-        }
 
         async function loadAnalytics() {
             if (document.hidden) return;
@@ -3551,9 +3307,11 @@
                       `<div class="hologram-text text-white font-bold">${s.name}</div>` +
                       `<div class="hologram-text text-cyan-glow text-sm font-bold">${s.status}</div>` +
                       `</div>` +
-                      `<div class="grid grid-cols-2 gap-3 text-xs">` +
+                      `<div class="grid grid-cols-4 gap-3 text-xs">` +
                       `<div><div class="hologram-text text-blade-amber/80">LAST UPDATE</div><div class="hologram-text text-white font-bold">${ts}</div></div>` +
+                      `<div><div class="hologram-text text-blade-amber/80">TRADES</div><div class="hologram-text text-white font-bold">${s.trades ?? 0}</div></div>` +
                       `<div><div class="hologram-text text-blade-amber/80">LATENCY</div><div class="hologram-text text-cyan-glow font-bold">${s.latency_ms}ms</div></div>` +
+                      `<div><div class="hologram-text text-blade-amber/80">PNL</div><div class="hologram-text text-cyan-glow font-bold">${typeof s.pnl === 'number' ? formatSol(s.pnl, solPrice) : '--'}</div></div>` +
                       `</div>`;
                   container.appendChild(div);
               });
@@ -4137,6 +3895,15 @@
                     dashboardState.dashboard.risk = data.risk;
                     updatePortfolioMetrics();
                     updateRiskMetrics();
+                    if (typeof loadMiniEquity === 'function') {
+                        loadMiniEquity();
+                    }
+                    if (typeof loadPositions === 'function') {
+                        loadPositions();
+                    }
+                    if (typeof loadHistory === 'function') {
+                        loadHistory();
+                    }
                 }
                 if (data.security) {
                     dashboardState.security = data.security;
@@ -4154,9 +3921,7 @@
             wsClient.connect('/features/ws', (data) => {
                 if (Array.isArray(data.features)) {
                     dashboardState.features = data.features;
-                    updateFeatureStream(data.features);
-                    const ts = data.event?.timestamp;
-                    renderFeatureSnapshot(data.features, ts);
+                    updateFeatureDiagnostics(data.features);
                 }
             });
             

--- a/web/public/js/analytics.js
+++ b/web/public/js/analytics.js
@@ -34,20 +34,36 @@ document.addEventListener('DOMContentLoaded', () => {
 
   tabs.forEach(btn => btn.addEventListener('click', () => activate(btn)));
   loadMiniEquity();
+  loadPerformanceMatrix();
+  pollRpcLatency();
+  setInterval(pollRpcLatency, 5000);
+  const p7 = document.getElementById('perf7d');
+  const p30 = document.getElementById('perf30d');
+  if (p7 && p30) {
+    p7.addEventListener('click', () => { strategyMatrixPeriod = '7d'; p7.classList.add('bg-blade-amber/20','text-blade-amber'); p30.classList.remove('bg-blade-amber/20','text-blade-amber'); p30.classList.add('bg-void-black/50','text-blade-amber/60'); loadPerformanceMatrix(); });
+    p30.addEventListener('click', () => { strategyMatrixPeriod = '30d'; p30.classList.add('bg-blade-amber/20','text-blade-amber'); p7.classList.remove('bg-blade-amber/20','text-blade-amber'); p7.classList.add('bg-void-black/50','text-blade-amber/60'); loadPerformanceMatrix(); });
+  }
+  initBacktestLab();
 });
 
 async function loadMiniEquity() {
   try {
-    const ctx = document.getElementById('portfolioSpark')?.getContext('2d');
+    const ctx = document.getElementById('sparkline')?.getContext('2d');
     if (!ctx || !window.Chart) return;
     const data = await fetch(`${API_BASE}/chart/portfolio?limit=48`).then(r => r.json());
     const series = data.series || [];
+    const labels = [];
+    const values = [];
+    for (let i = 0; i < series.length; i++) {
+      labels.push(i);
+      values.push(series[i][1]);
+    }
     if (miniEquityChart) miniEquityChart.destroy();
     miniEquityChart = new Chart(ctx, {
       type: 'line',
       data: {
-        labels: series.map((p, i) => i),
-        datasets: [{ data: series.map(p => p[1]), borderColor: '#ff8c00', borderWidth: 1, fill: false, tension: 0.1, pointRadius: 0 }],
+        labels,
+        datasets: [{ data: values, borderColor: '#ff8c00', borderWidth: 1, fill: false, tension: 0.1, pointRadius: 0 }],
       },
       options: { plugins: { legend: { display: false } }, scales: { x: { display: false }, y: { display: false } } },
     });
@@ -56,6 +72,84 @@ async function loadMiniEquity() {
   }
 }
 setInterval(loadMiniEquity, 30000);
+
+const root = typeof window !== 'undefined' ? window : globalThis;
+root.loadMiniEquity = loadMiniEquity;
+root.loadPerformanceMatrix = loadPerformanceMatrix;
+
+let strategyMatrixPeriod = '7d';
+
+async function loadPerformanceMatrix() {
+  try {
+    const data = await fetch(`${API_BASE}/strategy/performance_matrix?period=${strategyMatrixPeriod}`).then(r => r.json());
+    const grid = document.getElementById('perfMatrixGrid');
+    if (grid) {
+      grid.innerHTML = '';
+      data.days.forEach(v => {
+        const cell = document.createElement('div');
+        const color = v >= 0 ? 'bg-cyan-glow/70' : 'bg-blade-orange/60';
+        cell.className = `w-8 h-8 ${color} rounded`;
+        cell.title = `${v.toFixed(2)} SOL`;
+        grid.appendChild(cell);
+      });
+    }
+    const stratBox = document.getElementById('perfStrategyBreakdown');
+    if (stratBox) {
+      stratBox.innerHTML = '';
+      data.strategies.forEach(s => {
+        const box = document.createElement('div');
+        box.className = 'bg-void-black/50 p-3 rounded border border-blade-cyan/30';
+        box.innerHTML = `<div class="hologram-text text-cyan-glow font-bold text-sm">${s.name}</div>`+
+          `<div class="hologram-text text-white text-lg">${formatSol(s.pnl, solPrice)}</div>`+
+          `<div class="hologram-text text-cyan-glow text-xs">${formatPercent(s.win_rate)}</div>`;
+        stratBox.appendChild(box);
+      });
+    }
+    const sharpe = document.getElementById('perfSharpe');
+    const draw = document.getElementById('perfDrawdown');
+    const vol = document.getElementById('perfVol');
+    const calmar = document.getElementById('perfCalmar');
+    if (sharpe) sharpe.textContent = data.risk.sharpe.toFixed(2);
+    if (draw) draw.textContent = formatPercent(-data.risk.max_drawdown);
+    if (vol) vol.textContent = formatPercent(data.risk.volatility);
+    if (calmar) calmar.textContent = data.risk.calmar.toFixed(2);
+  } catch (e) {
+    console.warn('perf matrix load failed', e);
+  }
+}
+setInterval(loadPerformanceMatrix, 60000);
+
+function initBacktestLab() {
+  const btn = document.getElementById('runLab');
+  if (!btn) return;
+  btn.addEventListener('click', async () => {
+    const start = document.getElementById('labStart').value;
+    const end = document.getElementById('labEnd').value;
+    const sniper = parseFloat(document.getElementById('labSniper').value) || 0;
+    const arb = parseFloat(document.getElementById('labArb').value) || 0;
+    const mm = parseFloat(document.getElementById('labMM').value) || 0;
+    const params = { period: `${start}:${end}`, capital: 100, strategy_mix: `sniper:${sniper},arb:${arb},mm:${mm}` };
+    try {
+      const res = await apiClient.runBacktest(params);
+      const ws = new WebSocket(apiClient.getWebSocketURL(`/backtest/ws/${res.id}`));
+      ws.onmessage = ev => {
+        try {
+          const msg = JSON.parse(ev.data);
+          if (msg.pnl !== undefined) {
+            document.getElementById('labFinal').textContent = formatSol(msg.pnl, solPrice);
+            document.getElementById('labReturn').textContent = formatPercent(msg.pnl / params.capital);
+            document.getElementById('labTrades').textContent = msg.trades ?? '-';
+            document.getElementById('labWin').textContent = formatPercent(msg.win_rate ?? 0);
+            document.getElementById('labAvg').textContent = formatSol(msg.avg_trade ?? 0, solPrice);
+          }
+        } catch {}
+      };
+      ws.onclose = () => {};
+    } catch (e) {
+      console.error('backtest lab failed', e);
+    }
+  });
+}
 
 async function loadEquityCurve() {
   try {
@@ -117,12 +211,16 @@ async function loadMarketData() {
     tbody.innerHTML = '';
     markets.forEach(m => {
       const tr = document.createElement('tr');
-      tr.innerHTML = `<td class="px-2 py-1 cursor-pointer">${m.symbol}</td>` +
-        `<td class="px-2 py-1">${m.volume}</td>` +
-        `<td class="px-2 py-1">${m.volatility}</td>` +
-        `<td class="px-2 py-1">${m.liquidity}</td>` +
-        `<td class="px-2 py-1">${m.spread}</td>`;
-      tr.addEventListener('click', () => window.open(`${API_BASE}/chart/${m.symbol}`, '_blank'));
+      tr.className = 'cursor-pointer hover:bg-void-black/30';
+      tr.innerHTML = `<td class="px-2 py-1">${m.symbol}</td>` +
+        `<td class="px-2 py-1">${m.volume.toLocaleString()}</td>` +
+        `<td class="px-2 py-1">${formatPercent(m.volatility * 100)}</td>` +
+        `<td class="px-2 py-1">${m.liquidity.toLocaleString()}</td>` +
+        `<td class="px-2 py-1">${formatPercent(m.spread * 100)}</td>`;
+      tr.addEventListener('click', () => {
+        const sym = m.symbol.replace('/', '');
+        window.open(`https://www.tradingview.com/chart/?symbol=${sym}`, '_blank');
+      });
       tbody.appendChild(tr);
     });
   } catch (e) {
@@ -152,6 +250,10 @@ async function loadRegimeAnalysis(retries = 5, delay = 1000) {
   function connect(attempt) {
     try {
       const ws = new WebSocket(apiClient.getWebSocketURL('/posterior/ws'));
+      ws.onopen = () => {
+        const panel = document.getElementById('regimeChart');
+        if (panel) panel.hidden = false;
+      };
       ws.onmessage = evt => {
         try {
           const msg = JSON.parse(evt.data);
@@ -166,8 +268,7 @@ async function loadRegimeAnalysis(retries = 5, delay = 1000) {
           console.error('posterior ws parse failed', err);
         }
       };
-      ws.onerror = () => {
-        ws.close();
+      const handleClose = () => {
         const panel = document.getElementById('regimeChart');
         if (attempt < retries) {
           const wait = delay * Math.pow(2, attempt);
@@ -181,6 +282,8 @@ async function loadRegimeAnalysis(retries = 5, delay = 1000) {
           panel.parentNode?.insertBefore(msg, panel);
         }
       };
+      ws.onerror = handleClose;
+      ws.onclose = handleClose;
     } catch (e) {
       console.warn('regime analysis load failed', e);
       const panel = document.getElementById('regimeChart');
@@ -188,4 +291,77 @@ async function loadRegimeAnalysis(retries = 5, delay = 1000) {
     }
   }
   connect(0);
+}
+
+async function pollMevAlpha() {
+  const panel = document.getElementById('mevAlphaPanel');
+  if (!panel) return;
+  try {
+    const [mevRes, alphaRes, priceRes] = await Promise.all([
+      fetch(`${API_BASE}/mev/status`),
+      fetch(`${API_BASE}/alpha/signals`),
+      fetch(`${API_BASE}/price/sol`),
+    ]);
+    if (mevRes.status === 503 || alphaRes.status === 503) {
+      panel.classList.add('hidden');
+      return;
+    }
+    const [mev, alpha, priceData] = await Promise.all([
+      mevRes.json(),
+      alphaRes.json(),
+      priceRes.json(),
+    ]);
+    const price = priceData.price ?? priceData;
+    const savedEl = document.getElementById('mevSaved');
+    if (savedEl) savedEl.textContent = formatSol(mev.saved_today, price);
+    const blockedEl = document.getElementById('mevBlocked');
+    if (blockedEl) blockedEl.textContent = mev.attacks_blocked;
+    const successEl = document.getElementById('mevSuccess');
+    if (successEl) successEl.textContent = formatPercent(mev.success_rate);
+    const latencyEl = document.getElementById('mevLatency');
+    if (latencyEl) latencyEl.textContent = `${mev.latency_ms}ms`;
+    const strengthEl = document.getElementById('alphaStrength');
+    if (strengthEl) strengthEl.textContent = alpha.strength;
+    const sentEl = document.getElementById('alphaSentiment');
+    if (sentEl) sentEl.textContent = `${alpha.social_sentiment.toFixed(1)}/10`;
+    const momEl = document.getElementById('alphaMomentum');
+    if (momEl) momEl.textContent = `${alpha.onchain_momentum.toFixed(1)}/10`;
+    const whaleEl = document.getElementById('alphaWhales');
+    if (whaleEl) whaleEl.textContent = `${alpha.whale_activity.toFixed(1)}/10`;
+    panel.classList.remove('hidden');
+  } catch (e) {
+    console.warn('mev/alpha load failed', e);
+    panel.classList.add('hidden');
+  }
+}
+
+document.addEventListener('DOMContentLoaded', pollMevAlpha);
+setInterval(pollMevAlpha, 15000);
+
+const latencySamples = [];
+async function pollRpcLatency() {
+  try {
+    const res = await fetch(`${API_BASE}/health`).then(r => r.json());
+    const latency = res.rpc_latency_ms;
+    if (typeof latency === 'number') {
+      latencySamples.push(latency);
+      if (latencySamples.length > 5) latencySamples.shift();
+      const avg = latencySamples.reduce((a, b) => a + b, 0) / latencySamples.length;
+      const el = document.getElementById('rpcLatency');
+      if (el) {
+        el.textContent = `${avg.toFixed(0)}ms`;
+        el.classList.add('text-blade-amber');
+        setTimeout(() => el.classList.remove('text-blade-amber'), 500);
+      }
+      try {
+        localStorage.setItem('metricRpcLatency', String(avg));
+        const metric = document.getElementById('metricRpc');
+        if (metric) metric.textContent = `${avg.toFixed(0)}ms`;
+      } catch {}
+    }
+  } catch (e) {
+    console.error('rpc latency poll failed', e);
+    const el = document.getElementById('rpcLatency');
+    if (el) el.textContent = '--';
+  }
 }

--- a/web/public/js/debug.js
+++ b/web/public/js/debug.js
@@ -1,0 +1,57 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const consoleEl = document.getElementById('debugConsole');
+  const generateBtn = document.getElementById('generateLogs');
+  const clearBtn = document.getElementById('clearLogs');
+  const filterButtons = document.querySelectorAll('.log-filter');
+  const buffer = [];
+  const MAX = 500;
+  let level = 'ALL';
+
+  function render() {
+    if (!consoleEl) return;
+    consoleEl.innerHTML = '';
+    for (const entry of buffer) {
+      if (level !== 'ALL' && entry.level !== level) continue;
+      const div = document.createElement('div');
+      div.textContent = `[${new Date(entry.timestamp).toLocaleTimeString()}] ${entry.level}: ${entry.message}`;
+      consoleEl.appendChild(div);
+    }
+    consoleEl.scrollTop = consoleEl.scrollHeight;
+  }
+
+  function onLog(entry) {
+    buffer.push(entry);
+    if (buffer.length > MAX) buffer.shift();
+    render();
+  }
+
+  if (generateBtn) {
+    generateBtn.addEventListener('click', () => {
+      fetch(`${API_BASE}/logs/generate`, { method: 'POST' }).catch(() => {});
+    });
+  }
+
+  if (clearBtn) {
+    clearBtn.addEventListener('click', () => {
+      buffer.length = 0;
+      render();
+    });
+  }
+
+  filterButtons.forEach(btn => btn.addEventListener('click', () => {
+    level = btn.dataset.level;
+    render();
+  }));
+
+  try {
+    const ws = new WebSocket(apiClient.getWebSocketURL('/logs/ws'));
+    ws.onmessage = ev => {
+      try {
+        const msg = JSON.parse(ev.data);
+        onLog(msg);
+      } catch {}
+    };
+  } catch (e) {
+    console.warn('log ws failed', e);
+  }
+});

--- a/web/public/js/footer.js
+++ b/web/public/js/footer.js
@@ -1,6 +1,6 @@
 (function () {
     const footer = document.createElement('footer');
     footer.className = 'mt-8 text-xs text-center text-gray-400';
-    footer.innerHTML = '<a href="https://github.com/ijr-sol/sol-seeker" class="underline">GitHub</a> • © IJR Enterprises Inc. • <a href="disclaimer.html" class="underline">No investment advice</a>';
+    footer.innerHTML = '<a href="https://github.com/Ian-Reitsma/sol-seeker" class="underline">GitHub</a> • © IJR Enterprises Inc. • <a href="disclaimer.html" class="underline">No investment advice</a>';
     document.body.appendChild(footer);
 })();

--- a/web/public/js/nav.js
+++ b/web/public/js/nav.js
@@ -2,17 +2,35 @@ const navToggle = document.getElementById('nav-toggle');
 const sideMenu = document.getElementById('side-menu');
 const overlay = document.getElementById('menuOverlay');
 if (navToggle && sideMenu && overlay) {
+    let trapHandler;
     function openMenu() {
         navToggle.setAttribute('aria-expanded', 'true');
         sideMenu.classList.remove('hidden');
         overlay.classList.remove('hidden');
-        const firstLink = sideMenu.querySelector('a');
-        if (firstLink) firstLink.focus();
+        const focusable = sideMenu.querySelectorAll('a, button');
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        trapHandler = (e) => {
+            if (e.key === 'Tab') {
+                if (e.shiftKey && document.activeElement === first) {
+                    e.preventDefault();
+                    last.focus();
+                } else if (!e.shiftKey && document.activeElement === last) {
+                    e.preventDefault();
+                    first.focus();
+                }
+            } else if (e.key === 'Escape') {
+                closeMenu();
+            }
+        };
+        document.addEventListener('keydown', trapHandler);
+        if (first) first.focus();
     }
     function closeMenu() {
         navToggle.setAttribute('aria-expanded', 'false');
         sideMenu.classList.add('hidden');
         overlay.classList.add('hidden');
+        document.removeEventListener('keydown', trapHandler);
         navToggle.focus();
     }
     navToggle.addEventListener('click', () => {
@@ -20,7 +38,4 @@ if (navToggle && sideMenu && overlay) {
         expanded ? closeMenu() : openMenu();
     });
     overlay.addEventListener('click', closeMenu);
-    document.addEventListener('keydown', (e) => {
-        if (e.key === 'Escape') closeMenu();
-    });
 }

--- a/web/public/js/utils.js
+++ b/web/public/js/utils.js
@@ -1,12 +1,36 @@
+const root = typeof window !== 'undefined' ? window : globalThis;
+
+(function () {
+    if (typeof localStorage === 'undefined') return;
+    const theme = localStorage.getItem('setting_theme') || 'seeker';
+    setTheme(theme);
+})();
+
+function setTheme(theme) {
+    const html = document.documentElement;
+    html.classList.remove('theme-seeker', 'theme-dark', 'theme-light');
+    html.classList.add(`theme-${theme}`);
+    const disable = localStorage.getItem('setting_disableAnimation') === 'true';
+    if (theme === 'seeker' && !disable) {
+        html.classList.remove('no-anim');
+    } else {
+        html.classList.add('no-anim');
+    }
+    localStorage.setItem('setting_theme', theme);
+}
+
+root.setTheme = setTheme;
+
 function formatSol(amount, price) {
     const usd = amount * price;
-    return `${amount.toFixed(2)} SOL ($${usd.toFixed(2)})`;
+    const sign = amount < 0 ? '-' : '';
+    return `${sign}${Math.abs(amount).toFixed(2)} SOL (${sign}$${Math.abs(usd).toFixed(2)})`;
 }
 
 function formatSolChange(amount, price) {
     const usd = amount * price;
     const sign = amount >= 0 ? '+' : '-';
-    return `${sign}${Math.abs(amount).toFixed(2)} SOL ($${Math.abs(usd).toFixed(2)})`;
+    return `${sign}${Math.abs(amount).toFixed(2)} SOL (${sign}$${Math.abs(usd).toFixed(2)})`;
 }
 
 function formatPercent(value) {
@@ -14,7 +38,6 @@ function formatPercent(value) {
     return `${sign}${Math.abs(value).toFixed(2)}%`;
 }
 
-const root = typeof window !== 'undefined' ? window : globalThis;
 root.formatSol = formatSol;
 root.formatSolChange = formatSolChange;
 root.formatPercent = formatPercent;

--- a/web/public/js/walkthrough.js
+++ b/web/public/js/walkthrough.js
@@ -1,0 +1,39 @@
+const steps = [
+  { selector: '#portfolioValue', text: 'This shows your portfolio value in SOL and USD.' },
+  { selector: '#tradingToggle', text: 'Use Start to begin trading when ready.' },
+  { selector: '#strategyPerformance', text: 'Track strategy performance here.' },
+];
+
+function startWalkthrough() {
+  const overlay = document.getElementById('walkthroughOverlay');
+  const textEl = document.getElementById('walkthroughText');
+  const nextBtn = document.getElementById('walkthroughNext');
+  let index = 0;
+  overlay.classList.remove('hidden');
+  function showStep(i) {
+    const step = steps[i];
+    textEl.textContent = step.text;
+    document.querySelectorAll('.walk-highlight').forEach(el => el.classList.remove('ring-4','ring-blade-amber','walk-highlight'));
+    const el = document.querySelector(step.selector);
+    if (el) {
+      el.classList.add('ring-4','ring-blade-amber','walk-highlight');
+      el.scrollIntoView({behavior:'smooth', block:'center'});
+    }
+  }
+  nextBtn.onclick = () => {
+    index += 1;
+    if (index >= steps.length) {
+      document.querySelectorAll('.walk-highlight').forEach(el => el.classList.remove('ring-4','ring-blade-amber','walk-highlight'));
+      overlay.classList.add('hidden');
+      localStorage.setItem('basic_walkthrough_pending','false');
+      localStorage.setItem('basic_walkthrough_done','true');
+    } else {
+      showStep(index);
+    }
+  };
+  showStep(index);
+}
+
+if (localStorage.getItem('basic_walkthrough_pending') === 'true') {
+  window.addEventListener('load', startWalkthrough);
+}

--- a/web/public/mev.html
+++ b/web/public/mev.html
@@ -18,4 +18,5 @@
     <!-- TODO: Implement warning banners when MEV protection is inactive. -->
     <!-- TODO: Include footer once global footer implemented. -->
 </body>
+<script src="js/footer.js"></script>
 </html>

--- a/web/public/openapi.json
+++ b/web/public/openapi.json
@@ -359,6 +359,26 @@
         }
       }
     },
+    "/risk/rug": {
+      "get": {
+        "summary": "Risk Rug Endpoint",
+        "description": "Return current rug pull alerts.",
+        "operationId": "risk_rug_endpoint_risk_rug_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Risk Rug Endpoint Risk Rug Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/assets": {
       "get": {
         "summary": "Assets Endpoint",
@@ -465,10 +485,33 @@
         }
       }
     },
+    "/market/active": {
+      "get": {
+        "summary": "Market Active",
+        "description": "Return basic stats for active market pairs.",
+        "operationId": "market_active_market_active_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/MarketStat"
+                  },
+                  "type": "array",
+                  "title": "Response Market Active Market Active Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/sentiment/trending": {
       "get": {
         "summary": "Sentiment Trending",
-        "description": "Return currently trending tokens with sentiment data.",
+        "description": "Return currently trending tokens with sentiment data.\n\nThis stub pulls from the in-memory collectors fed by\n``solbot.social.twitter`` and ``solbot.social.telegram`` modules.  The\ncollectors are lightweight and primarily used for tests and demo mode\nso we seed a few memecoin examples when no live data is present.",
         "operationId": "sentiment_trending_sentiment_trending_get",
         "responses": {
           "200": {
@@ -755,6 +798,83 @@
                   },
                   "type": "array",
                   "title": "Response Strategy Matrix Strategy Matrix Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/strategy/performance_matrix": {
+      "get": {
+        "summary": "Strategy Performance Matrix",
+        "description": "Return recent strategy performance metrics.",
+        "operationId": "strategy_performance_matrix_strategy_performance_matrix_get",
+        "parameters": [
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Period",
+              "default": "7d"
+            },
+            "name": "period",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PerformanceMatrix"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mev/status": {
+      "get": {
+        "summary": "Mev Status Endpoint",
+        "operationId": "mev_status_endpoint_mev_status_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MevStatus"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/alpha/signals": {
+      "get": {
+        "summary": "Alpha Signals Endpoint",
+        "operationId": "alpha_signals_endpoint_alpha_signals_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlphaSignals"
                 }
               }
             }
@@ -1049,6 +1169,26 @@
         ]
       }
     },
+    "/logs/generate": {
+      "post": {
+        "summary": "Logs Generate",
+        "description": "Generate sample log entries for the debug console.",
+        "operationId": "logs_generate_logs_generate_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Logs Generate Logs Generate Post"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/chart/portfolio": {
       "get": {
         "summary": "Chart Portfolio",
@@ -1223,6 +1363,34 @@
   },
   "components": {
     "schemas": {
+      "AlphaSignals": {
+        "properties": {
+          "strength": {
+            "type": "string",
+            "title": "Strength"
+          },
+          "social_sentiment": {
+            "type": "number",
+            "title": "Social Sentiment"
+          },
+          "onchain_momentum": {
+            "type": "number",
+            "title": "Onchain Momentum"
+          },
+          "whale_activity": {
+            "type": "number",
+            "title": "Whale Activity"
+          }
+        },
+        "type": "object",
+        "required": [
+          "strength",
+          "social_sentiment",
+          "onchain_momentum",
+          "whale_activity"
+        ],
+        "title": "AlphaSignals"
+      },
       "ArbitrageStat": {
         "properties": {
           "status": {
@@ -1502,6 +1670,26 @@
           "strategy_risk": {
             "type": "string",
             "title": "Strategy Risk"
+          },
+          "mev_status": {
+            "type": "string",
+            "title": "Mev Status"
+          },
+          "alpha_signals": {
+            "type": "string",
+            "title": "Alpha Signals"
+          },
+          "logs_generate": {
+            "type": "string",
+            "title": "Logs Generate"
+          },
+          "risk_rug": {
+            "type": "string",
+            "title": "Risk Rug"
+          },
+          "market_active": {
+            "type": "string",
+            "title": "Market Active"
           }
         },
         "type": "object",
@@ -1546,7 +1734,12 @@
           "news",
           "strategy_performance",
           "strategy_breakdown",
-          "strategy_risk"
+          "strategy_risk",
+          "mev_status",
+          "alpha_signals",
+          "logs_generate",
+          "risk_rug",
+          "market_active"
         ],
         "title": "EndpointMap"
       },
@@ -1746,6 +1939,39 @@
         ],
         "title": "Manifest"
       },
+      "MarketStat": {
+        "properties": {
+          "symbol": {
+            "type": "string",
+            "title": "Symbol"
+          },
+          "volume": {
+            "type": "number",
+            "title": "Volume"
+          },
+          "volatility": {
+            "type": "number",
+            "title": "Volatility"
+          },
+          "liquidity": {
+            "type": "number",
+            "title": "Liquidity"
+          },
+          "spread": {
+            "type": "number",
+            "title": "Spread"
+          }
+        },
+        "type": "object",
+        "required": [
+          "symbol",
+          "volume",
+          "volatility",
+          "liquidity",
+          "spread"
+        ],
+        "title": "MarketStat"
+      },
       "Metrics": {
         "properties": {
           "cpu": {
@@ -1762,6 +1988,34 @@
         },
         "type": "object",
         "title": "Metrics"
+      },
+      "MevStatus": {
+        "properties": {
+          "saved_today": {
+            "type": "number",
+            "title": "Saved Today"
+          },
+          "attacks_blocked": {
+            "type": "integer",
+            "title": "Attacks Blocked"
+          },
+          "success_rate": {
+            "type": "number",
+            "title": "Success Rate"
+          },
+          "latency_ms": {
+            "type": "number",
+            "title": "Latency Ms"
+          }
+        },
+        "type": "object",
+        "required": [
+          "saved_today",
+          "attacks_blocked",
+          "success_rate",
+          "latency_ms"
+        ],
+        "title": "MevStatus"
       },
       "NetworkStats": {
         "properties": {
@@ -1883,6 +2137,34 @@
         ],
         "title": "OrderResponse"
       },
+      "PerformanceMatrix": {
+        "properties": {
+          "days": {
+            "items": {
+              "type": "number"
+            },
+            "type": "array",
+            "title": "Days"
+          },
+          "strategies": {
+            "items": {
+              "$ref": "#/components/schemas/StrategyPerf"
+            },
+            "type": "array",
+            "title": "Strategies"
+          },
+          "risk": {
+            "$ref": "#/components/schemas/StrategyRisk"
+          }
+        },
+        "type": "object",
+        "required": [
+          "days",
+          "strategies",
+          "risk"
+        ],
+        "title": "PerformanceMatrix"
+      },
       "PosteriorSnapshot": {
         "properties": {
           "rug": {
@@ -1941,6 +2223,10 @@
           "fomo_pct": {
             "type": "number",
             "title": "Fomo Pct"
+          },
+          "timestamp": {
+            "type": "integer",
+            "title": "Timestamp"
           }
         },
         "type": "object",
@@ -2152,6 +2438,14 @@
           "latency_ms": {
             "type": "integer",
             "title": "Latency Ms"
+          },
+          "trades": {
+            "type": "integer",
+            "title": "Trades"
+          },
+          "pnl": {
+            "type": "number",
+            "title": "Pnl"
           }
         },
         "type": "object",

--- a/web/public/sentiment.html
+++ b/web/public/sentiment.html
@@ -13,10 +13,51 @@
          - Footer must link to repo and show © IJR Enterprises Inc. disclaimer. -->
         <link rel="stylesheet" href="dashboard.css">
 </head>
-<body class="text-white font-display min-h-screen">
-    <!-- TODO: Shared header/side menu. -->
-    <!-- TODO: Main layout with three columns: Trending, Influencer Alerts, Community Pulse. -->
-    <!-- TODO: Each section updates live and supports clicking tokens to open detailed dashboard. -->
-    <!-- TODO: Include footer once global footer implemented. -->
+<body class="text-white font-display min-h-screen p-6 space-y-6">
+    <section>
+        <h2 class="text-xl mb-2">Trending Now</h2>
+        <ul id="sentTrending" class="space-y-1 text-sm"></ul>
+    </section>
+    <section>
+        <h2 class="text-xl mb-2">Influencer Alerts</h2>
+        <ul id="sentInfluencers" class="space-y-1 text-sm"></ul>
+    </section>
+    <section>
+        <h2 class="text-xl mb-2">Community Pulse</h2>
+        <div id="sentPulse" class="text-sm"></div>
+    </section>
+
+    <script src="js/utils.js"></script>
+    <script>
+        async function loadSentiment() {
+            try {
+                const [trending, influencers, pulse] = await Promise.all([
+                    fetch(`${API_BASE}/sentiment/trending`).then(r => r.json()),
+                    fetch(`${API_BASE}/sentiment/influencers`).then(r => r.json()),
+                    fetch(`${API_BASE}/sentiment/pulse`).then(r => r.json())
+                ]);
+                const tList = document.getElementById('sentTrending');
+                tList.innerHTML = '';
+                trending.forEach(t => {
+                    const li = document.createElement('li');
+                    li.textContent = `${t.symbol} – ${t.mentions} mentions (${t.sentiment})`;
+                    tList.appendChild(li);
+                });
+                const iList = document.getElementById('sentInfluencers');
+                iList.innerHTML = '';
+                influencers.forEach(a => {
+                    const li = document.createElement('li');
+                    li.textContent = `${a.handle}: ${a.message}`;
+                    iList.appendChild(li);
+                });
+                const pulseDiv = document.getElementById('sentPulse');
+                pulseDiv.textContent = `Fear/Greed: ${pulse.fear_greed} • Social Volume: ${pulse.social_volume} • FOMO: ${pulse.fomo}`;
+            } catch (e) {
+                console.warn('sentiment load failed', e);
+            }
+        }
+        loadSentiment();
+    </script>
 </body>
+<script src="js/footer.js"></script>
 </html>

--- a/web/public/settings.html
+++ b/web/public/settings.html
@@ -12,13 +12,13 @@
     <section class="p-6" id="timeSection">
         <h2 class="text-xl mb-4">Time & Time Zone</h2>
         <label class="block mb-2">Time Zone:
-            <input id="timeZone" class="text-black" type="text">
+            <select id="timeZone" class="text-black"></select>
         </label>
         <div>Current Time: <span id="currentTime">--:--:--</span></div>
     </section>
 
     <section class="p-6" id="systemHealthSection">
-        <h2 class="text-xl mb-4">System Health</h2>
+        <h2 class="text-xl mb-4">System Status &amp; Resource Usage</h2>
         <div>CPU: <span id="metricCpu">--%</span></div>
         <div>RAM: <span id="metricMem">--%</span></div>
         <div>RPC Latency: <span id="metricRpc">--ms</span></div>
@@ -26,14 +26,45 @@
 
     <section class="p-6" id="configSection">
         <h2 class="text-xl mb-4">Config</h2>
+        <label class="block mb-2">Theme:
+            <select id="theme" class="text-black">
+                <option value="seeker">Seeker</option>
+                <option value="dark">Dark</option>
+                <option value="light">Light</option>
+            </select>
+        </label>
         <label class="block mb-2">
             <input type="checkbox" id="advancedToggle"> Advanced Mode
+        </label>
+        <label class="block mb-2">
+            <input type="checkbox" id="disableAnimation"> Disable Background Animation
         </label>
         <label class="block">Trading Mode:
             <select id="tradingMode" class="text-black">
                 <option value="demo">Demo</option>
                 <option value="live">Live</option>
             </select>
+        </label>
+        <label class="block mt-2">Primary Asset:
+            <input id="primaryAsset" list="assetOptions" class="text-black" />
+            <datalist id="assetOptions">
+                <option value="SOL"></option>
+                <option value="BONK"></option>
+                <option value="WIF"></option>
+                <option value="FIDA"></option>
+                <option value="JUP"></option>
+                <option value="RAY"></option>
+                <option value="ORCA"></option>
+                <option value="MNGO"></option>
+                <option value="SAMO"></option>
+                <option value="STEP"></option>
+                <option value="PORT"></option>
+                <option value="SLND"></option>
+                <option value="SBR"></option>
+                <option value="CWAR"></option>
+                <option value="SHDW"></option>
+                <option value="Other"></option>
+            </datalist>
         </label>
     </section>
 
@@ -53,8 +84,9 @@
 
     <section class="p-6 advanced hidden" id="strategyModulesSection">
         <h2 class="text-xl mb-4">Strategy Modules</h2>
-        <label class="block"><input type="checkbox" id="stratMomentum"> Momentum</label>
-        <label class="block"><input type="checkbox" id="stratMean"> Mean Reversion</label>
+        <label class="block"><input type="checkbox" id="enableSniper"> Listing Sniper</label>
+        <label class="block"><input type="checkbox" id="enableArbitrage"> Arbitrage Engine</label>
+        <label class="block"><input type="checkbox" id="enableMarketMaking"> Market Making</label>
     </section>
 
     <section class="p-6 advanced hidden" id="moduleStatusSection">

--- a/web/public/strategies.html
+++ b/web/public/strategies.html
@@ -22,4 +22,5 @@
     <!-- TODO: Include guidance text explaining each setting for beginner (basic mode) vs advanced mode toggle. -->
     <!-- TODO: Include footer once global footer implemented. -->
 </body>
+<script src="js/footer.js"></script>
 </html>

--- a/web/public/whales.html
+++ b/web/public/whales.html
@@ -20,4 +20,5 @@
     <!-- TODO: Add pagination or infinite scroll to handle long histories. -->
     <!-- TODO: Include footer once global footer implemented. -->
 </body>
+<script src="js/footer.js"></script>
 </html>

--- a/web/tests/utils_format.test.ts
+++ b/web/tests/utils_format.test.ts
@@ -7,8 +7,8 @@ describe('utils formatters', () => {
   });
 
   test('formatSolChange handles sign', () => {
-    expect(formatSolChange(-1.5, 20)).toBe('-1.50 SOL ($30.00)');
-    expect(formatSolChange(1.5, 20)).toBe('+1.50 SOL ($30.00)');
+    expect(formatSolChange(-1.5, 20)).toBe('-1.50 SOL (-$30.00)');
+    expect(formatSolChange(1.5, 20)).toBe('+1.50 SOL (+$30.00)');
   });
 
   test('formatPercent adds sign', () => {


### PR DESCRIPTION
## Summary
- add exponential backoff retries for regime websocket and hide panel after repeated failures
- introduce one-time basic-mode walkthrough overlay for new users
- allow light/dark/seeker themes with reduced background animation and persist selection
- return HTTP 409 on redundant engine start/stop requests with dashboard toast feedback

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a07d2e01d4832eb2de473f7b601a13